### PR TITLE
Add a retry to deal with CDN delay on download

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -185,3 +185,31 @@ rootURL <- function (x, obj=session_store$root) {
         return(NULL)
     }
 }
+
+retry <- function (expr, wait=.1, max.tries=10) {
+    ## Retry (e.g. a request)
+    e <- substitute(expr)
+    tries <- 0
+    while (tries < max.tries) {
+        out <- try(eval.parent(e), silent=TRUE)
+        if (inherits(out, "try-error")) {
+            tries <- tries + 1
+            Sys.sleep(wait)
+        } else {
+            tries <- max.tries
+        }
+    }
+    if (is.error(out)) {
+        stop(out)
+    }
+    return(out)
+}
+
+#' @importFrom utils download.file
+crDownload <- function (url, file, ...) {
+    ## Retry is for delay in propagating the file to the CDN
+    ## TODO: consider only "retry" if `url` is in CDN (don't want to retry
+    ## necessarily on every url/server response)
+    retry(download.file(url, file, quiet=TRUE, ...))
+    return(file)
+}

--- a/R/export-dataset.R
+++ b/R/export-dataset.R
@@ -24,7 +24,6 @@
 #' \code{FALSE}).
 #' @return Invisibly, \code{file}.
 #' @export
-#' @importFrom utils download.file
 exportDataset <- function (dataset, file, format=c("csv", "spss"),
                            categorical=c("name", "id"), na=NULL,
                            varlabel=c("name", "description"), ...) {
@@ -54,7 +53,7 @@ exportDataset <- function (dataset, file, format=c("csv", "spss"),
     }
 
     result <- crPOST(export_url, body=toJSON(body))
-    download.file(result, file, quiet=TRUE) ## Note outside of auth. Ok because file is in s3 with token
+    file <- crDownload(result, file)
     invisible(file)
 }
 

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -68,8 +68,9 @@ tabBook <- function (multitable, dataset, weight=crunch::weight(dataset),
     ## POST the query, which (after progress polling) returns a URL to download
     result <- crPOST(tabbook_url, config=add_headers(`Accept`=accept),
         body=toJSON(body))
-    download.file(result, file, quiet=TRUE) ## Note outside of auth. Ok because file is in s3 with token
+    file <- crDownload(result, file)
     if (f == "json") {
+        ## TODO: instead of downloading a file, crGET?
         ## Read in the tab book content and turn it into useful objects
         return(TabBookResult(fromJSON(file, simplifyVector=FALSE)))
     } else {

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -35,6 +35,19 @@ with_mock_crunch({
     })
 })
 
+test_that("retry", {
+    counter <- 0
+    f <- function () {
+        counter <<- counter + 1
+        stopifnot(counter == 3)
+        return(counter)
+    }
+    expect_identical(retry(f(), wait=.001), 3)
+    counter <- 0
+    expect_error(retry(f(), wait=.001, max.tries=2),
+        "counter == 3 is not TRUE")
+})
+
 if (run.integration.tests) {
     test_that("Request headers", {
         skip_if_disconnected()


### PR DESCRIPTION
I wanted to touch up the branch where you had added the retry function while I was on the plane, but I didn't have it in my local checkout, so I just redid it. Got a better test for `retry` and factored out a `crDownload` function.