### PR TITLE
Dichotomize derive array

### DIFF
--- a/R/make-array.R
+++ b/R/make-array.R
@@ -5,13 +5,14 @@
 #' a Dataset)
 #' @param name character, the name that the new Categorical Array variable
 #' should have. Required.
-#' @param selections character, for \code{makeMR}, the names of the
+#' @param selections character, for `makeMR` and `deriveArray` the names of the
 #' categories to mark as the dichotomous selections. Required for
-#' \code{makeMR}; ignored in \code{makeArray}.
+#' `makeMR`; optional for `deriveArray`; ignored in `makeArray`.
 #' @param ... Optional additional attributes to set on the new variable.
 #' @return A VariableDefinition that when added to a Dataset will create the
-#' categorical-array or multiple-response variable. \code{deriveArray} will
-#' make a derived array expression, while \code{makeArray} and \code{makeMR}
+#' categorical-array or multiple-response variable. `deriveArray` will
+#' make a derived array expression (or a derived multiple response expression
+#' if `selections` are supplied), while `makeArray` and `makeMR`
 #' return an expression that "binds" variables together, removing them from
 #' independent existence.
 #' @export
@@ -91,6 +92,12 @@ deriveArray <- function (subvariables, name, selections, ...) {
         list(value=I(subvarids))))
 
     if (!missing(selections)) {
+        # if there are selections, wrap the array function inside of a
+        # select_categories function
+        if(!is.list(selections)){
+            # if selections is not already a list convert it to one.
+            selections <- as.list(selections)
+        }
         derivation <- zfunc("select_categories", derivation, list(value=selections))
     }
 

--- a/R/make-array.R
+++ b/R/make-array.R
@@ -76,7 +76,7 @@ makeMR <- function (subvariables, name, selections, ...) {
 
 #' @rdname makeArray
 #' @export
-deriveArray <- function (subvariables, name, ...) {
+deriveArray <- function (subvariables, name, selections, ...) {
     ## Get subvariable URLs
     if (is.dataset(subvariables)) {
         ## as in, if the list of variables is a [ extraction from a Dataset
@@ -89,6 +89,10 @@ deriveArray <- function (subvariables, name, ...) {
         list(map=structure(lapply(subvariables, function (x) list(variable=x)),
             .Names=subvarids)),
         list(value=I(subvarids))))
+
+    if (!missing(selections)) {
+        derivation <- zfunc("select_categories", derivation, list(value=selections))
+    }
 
     return(VariableDefinition(derivation=derivation, name=name, ...))
 }

--- a/man/makeArray.Rd
+++ b/man/makeArray.Rd
@@ -10,7 +10,7 @@ makeArray(subvariables, name, ...)
 
 makeMR(subvariables, name, selections, ...)
 
-deriveArray(subvariables, name, ...)
+deriveArray(subvariables, name, selections, ...)
 }
 \arguments{
 \item{subvariables}{a list of Variable objects to bind together, or a
@@ -22,14 +22,15 @@ should have. Required.}
 
 \item{...}{Optional additional attributes to set on the new variable.}
 
-\item{selections}{character, for \code{makeMR}, the names of the
+\item{selections}{character, for \code{makeMR} and \code{deriveArray} the names of the
 categories to mark as the dichotomous selections. Required for
-\code{makeMR}; ignored in \code{makeArray}.}
+\code{makeMR}; optional for \code{deriveArray}; ignored in \code{makeArray}.}
 }
 \value{
 A VariableDefinition that when added to a Dataset will create the
 categorical-array or multiple-response variable. \code{deriveArray} will
-make a derived array expression, while \code{makeArray} and \code{makeMR}
+make a derived array expression (or a derived multiple response expression
+if \code{selections} are supplied), while \code{makeArray} and \code{makeMR}
 return an expression that "binds" variables together, removing them from
 independent existence.
 }

--- a/tests/testthat/test-derive-array.R
+++ b/tests/testthat/test-derive-array.R
@@ -29,6 +29,16 @@ with_test_authentication({
         expect_identical(as.vector(ds$derivedarray[[1]]), q1.values)
     })
 
+    mr_derivation <- deriveArray(list(ds$q1, ds$petloc$petloc_home), selections=c("Dog"), name="Derived pets MR") # cat dog has id 2
+    ds$derivedmr <- mr_derivation
+    test_that("deriveArray can also derive MRs", {
+        expect_true(is.MR(ds$derivedmr))
+        expect_identical(names(subvariables(ds$derivedmr)), c("Pet", "Home"))
+        expect_identical(names(categories(ds$derivedmr)),
+                         c("Cat", "Dog", "Bird", "Skipped", "Not Asked"))
+        expect_identical(as.vector(ds$derivedmr[[1]]), q1.values)
+    })
+
     test_that("Can edit metadata of the derived array, and parents are unaffected", {
         aliases(subvariables(ds$derivedarray)) <- c("dsub1", "dsub2")
         expect_identical(aliases(subvariables(ds$derivedarray)),


### PR DESCRIPTION
`deriveArray()` now can accept (and will use!) a `selections` argument. When `selections` is provided, a multiple response variable will be derived instead of a categorical array.