### PR TITLE
Fixed `changeCategoryID()` to not always update the numeric value of the category.

### DIFF
--- a/R/categories.R
+++ b/R/categories.R
@@ -254,7 +254,9 @@ setMethod("lapply", "Categories", function (X, FUN, ...) {
 #'
 #' Changes the id of a category from an existing value to a new one.
 #' The variable can be a categorical, categorical array, or multiple response
-#' variable.
+#' variable. The category changed will have the same numeric value and missing
+#' status as before. The one exception to this is if the numeric value is the 
+#' same as the id, then the new numeric value will be the same as the new id.
 #'
 #' @param variable the variable in a crunch dataset that will be changed (note: the variable must be categorical, categorical array, or multiple response)
 #' @param from the (old) id identifying the category you want to change
@@ -289,9 +291,11 @@ changeCategoryID <- function (variable, from, to) {
 
     ## Add new category
     newcat <- categories(variable)[[pos.from]]
+    if (newcat$id == newcat$numeric_value %||% FALSE) {
+        newcat$numeric_value <- to
+    }
     newcat$id <- to
-    newcat$numeric_value <- to
-
+    
     names(categories(variable))[pos.from] <- "__TO_DELETE__"
     categories(variable) <- c(categories(variable), newcat)
 

--- a/R/categories.R
+++ b/R/categories.R
@@ -291,6 +291,9 @@ changeCategoryID <- function (variable, from, to) {
 
     ## Add new category
     newcat <- categories(variable)[[pos.from]]
+    # if the old id matches the old numeric value, likely the user wants these 
+    # to be the same, so change the new numeric value to be the same as the 
+    # new id.
     if (newcat$id == newcat$numeric_value %||% FALSE) {
         newcat$numeric_value <- to
     }

--- a/man/changeCategoryID.Rd
+++ b/man/changeCategoryID.Rd
@@ -19,7 +19,9 @@ changeCategoryID(variable, from, to)
 \description{
 Changes the id of a category from an existing value to a new one.
 The variable can be a categorical, categorical array, or multiple response
-variable.
+variable. The category changed will have the same numeric value and missing
+status as before. The one exception to this is if the numeric value is the
+same as the id, then the new numeric value will be the same as the new id.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-categories.R
+++ b/tests/testthat/test-categories.R
@@ -350,14 +350,51 @@ with_test_authentication({
                 c(1, 2, -1))
             orig_vector <- as.vector(ds$v4f)
             expect_equal(as.vector(ds$v4f[1:4], mode="id"), c(1, 2, 1, 2))
-
-            ds$v4f <- changeCategoryID(ds$v4f, 2, 6)
+            
+            expect_silent(ds$v4f <- changeCategoryID(ds$v4f, 2, 6))
             expect_identical(names(categories(ds$v4f)),
                 c("B", "C", "No Data"))
             expect_equal(ids(categories(ds$v4f)),
                 c(1, 6, -1))
             expect_equal(as.vector(ds$v4f), orig_vector)
             expect_equal(as.vector(ds$v4f[1:4], mode="id"), c(1, 6, 1, 6))
+            expect_equal(as.vector(ds$v4f[1:4], mode="numeric"), c(1, 6, 1, 6))
+        })
+        
+        test_that("Can changeCategoryID without changing values when value!=id", {
+            ds$v4g <- df$v4
+            values(categories(ds$v4g)) <- c(NA, 20, NA)
+            expect_identical(names(categories(ds$v4g)),
+                             c("B", "C", "No Data"))
+            expect_equal(ids(categories(ds$v4g)),
+                         c(1, 2, -1))
+            expect_equal(values(categories(ds$v4g)),
+                         c(NA, 20, NA))
+            orig_vector <- as.vector(ds$v4g)
+            expect_equal(as.vector(ds$v4g[1:4], mode="id"), c(1, 2, 1, 2))
+            
+            
+            expect_silent(ds$v4g <- changeCategoryID(ds$v4g, 2, 6))
+            expect_identical(names(categories(ds$v4g)),
+                             c("B", "C", "No Data"))
+            expect_equal(ids(categories(ds$v4g)),
+                         c(1, 6, -1))
+            expect_equal(values(categories(ds$v4g)),
+                         c(NA, 20, NA))
+            expect_equal(as.vector(ds$v4g), orig_vector)
+            expect_equal(as.vector(ds$v4g[1:4], mode="id"), c(1, 6, 1, 6))
+            expect_equal(as.vector(ds$v4g[1:4], mode="numeric"), c(NA, 20, NA, 20))
+            
+            # also try with an NA, make sure the NA is retained
+            expect_silent(ds$v4g <- changeCategoryID(ds$v4g, 1, 10))
+            expect_identical(names(categories(ds$v4g)),
+                             c("B", "C", "No Data"))
+            expect_equal(ids(categories(ds$v4g)),
+                         c(10, 6, -1))
+            expect_equal(values(categories(ds$v4g)),
+                         c(NA, 20, NA))
+            expect_equal(as.vector(ds$v4g[1:4], mode="id"), c(10, 6, 10, 6))
+            expect_equal(as.vector(ds$v4g[1:4], mode="numeric"), c(NA, 20, NA, 20))
         })
 
         test_that("Can changeCategoryID for array variables", {


### PR DESCRIPTION
Added tests of numeric value changes when using `changeCategoryID()` `changeCategoryID()` no longer always makes the numeric value the same as the new ID. This addresses issue #103 