### PR TITLE
addGeoMetadata updates

### DIFF
--- a/R/geo.R
+++ b/R/geo.R
@@ -73,8 +73,8 @@ setMethod("geo<-", c("CrunchVariable", "NULL"),
 #' Add geodata metadata to a crunch variable
 #'
 #' If the variable matches a single geographic shapefile hosted by crunch, 
-#' `addGeoMetadata` will make the appropriate `[CrunchGeography]` to add to a 
-#' variable's `geo()` metadata. It matches based on how well the contents of the
+#' `addGeoMetadata` will make the appropriate [`CrunchGeography`] to add to a 
+#' variable's [`geo()`] metadata. It matches based on how well the contents of the
 #' variable match the feature properties that are in each shapefile.
 #' 
 #' If more than one property of the same geographic shapefile has the same
@@ -83,19 +83,22 @@ setMethod("geo<-", c("CrunchVariable", "NULL"),
 #' If more than one geographic shapefile has the same highest matching score, an
 #' error will be printed listing the geographic shapefiles that matched. 
 #' Information from this error can be used to setup an appropriate 
-#' `[CrunchGeography]` by hand to connect a variable with the metadata needed.
+#' [`CrunchGeography`] by hand to connect a variable with the metadata needed.
 #'
 #' @param variable a Crunch variable to use for matching. This must be either
 #' a text or a categorical variable.
+#' @param ... arguments passed on to [`matchCatToFeat()`] for example a set of
+#' available geographic features as `all_features` if you want to limit the 
+#' number of features to be considered.
 #'
-#' @return a `[CrunchGeography]` object that can be assigned into `geo(variable)`
+#' @return a [`CrunchGeography`] object that can be assigned into `geo(variable)`
 #'
 #' @examples
 #' \dontrun{
 #' geo(ds$state) <- addGeoMetadata(ds$state)
 #' }
 #' @export
-addGeoMetadata <- function (variable) {
+addGeoMetadata <- function (variable, ...) {
     match_field <- "name" ## TODO: should this be a param?
     # Validate
     if (!is.variable(variable)) {
@@ -112,7 +115,7 @@ addGeoMetadata <- function (variable) {
              " is neither a categorical or text variable.")
     }
 
-    match_scores <- matchCatToFeat(cats)
+    match_scores <- matchCatToFeat(cats, ...)
 
     if (max(match_scores$value, na.rm = TRUE) == 0) {
         halt("None of the geographies match at all. Either the variable is",
@@ -130,13 +133,7 @@ addGeoMetadata <- function (variable) {
                     "). Using ", dQuote(match_scores$property[1]), ".")
             match_scores <- match_scores[1,]
         } else {
-            halt("There is more than one possible match. Please specify the ", 
-                 "geography manually:\n", paste0(
-                     capture.output(print(match_scores[,c("value", 
-                                                          "geodatum_name",
-                                                          "geodatum",
-                                                          "property")])),
-                     collapse = "\n"))   
+            halt(multiMatchHelper(match_scores, match_field, deparse(substitute(variable))))
         }
     }
 
@@ -144,6 +141,32 @@ addGeoMetadata <- function (variable) {
                           feature_key=paste0('properties.',match_scores$property),
                           match_field=match_field)
     return(match_geo)
+}
+
+# format the error message when there are multiple matches
+multiMatchHelper <- function (match_scores, match_field, quoted_var) {
+    msg <- c("There is more than one possible match. You will need to specify ", 
+             "the geography manually using one of the following ",
+             "CrunchGeographies:\n")
+    
+    calls <- apply(match_scores, 1, function(match_row) {
+        # TODO: add coloring to this message when crayon is available
+        header <- c(
+            sprintf("To add the geography: %s\nmatched to the property: %s\n",
+                    match_row["geodatum_name"], match_row["property"]),
+            "set the variable's geographic mapping with following:\n"
+        )
+        geo_call <- paste0("geo(", quoted_var, ") <- ", CrunchGeoCall(match_row["geodatum"],
+                                  match_row["property"],
+                                  match_field))
+        return(c(header, geo_call, "\n\n"))
+    })
+    return(c(msg, calls))
+}
+
+CrunchGeoCall <- function (geodatum, feature_key, match_field) {
+    return(sprintf("CrunchGeography(geodatum='%s', feature_key='properties.%s',
+                   match_field='%s')", geodatum, feature_key, match_field))
 }
 
 #' @rdname crunch-is
@@ -176,7 +199,7 @@ availableGeodataFeatures <- function (x = getAPIRoot(),
     # but the current API requires it.
     geo_metadatas <- lapply(urls(geo_cat), function (x) Geodata(crGET(x)))
     names(geo_metadatas) <- urls(geo_cat)
-
+    
     out <- lapply(geo_metadatas, function (geography) {
         meta <- geography$metadata$properties
         lapply(names(meta), function (x) {
@@ -187,6 +210,9 @@ availableGeodataFeatures <- function (x = getAPIRoot(),
         })
     })
 
+    # remove any elements that didn't have any metadata
+    out <- out[vapply(out, length, numeric(1)) > 0]
+    
     out <- lapply(names(out), function (x) {
         dfs <- do.call("rbind", out[[x]])
         dfs$geodatum <- x

--- a/R/geo.R
+++ b/R/geo.R
@@ -58,7 +58,6 @@ setMethod("geo<-", c("CrunchVariable", "CrunchGeography"),
               geodata <- list(geodata = list(value))
 
               ent <- setEntitySlot(entity(x), "view", geodata)
-              dropCache(datasetReference(x))
               return(x)
           })
 #' @rdname geo

--- a/R/geo.R
+++ b/R/geo.R
@@ -58,7 +58,7 @@ setMethod("geo<-", c("CrunchVariable", "CrunchGeography"),
               geodata <- list(geodata = list(value))
 
               ent <- setEntitySlot(entity(x), "view", geodata)
-              dropCache(cubeURL(x))
+              dropCache(datasetReference(x))
               return(x)
           })
 #' @rdname geo

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -142,6 +142,8 @@ rmarkdown
 sav
 savepoints
 searchable
+shapefile
+shapefiles
 shojiObject
 spss
 st

--- a/inst/app.crunch.io/api/geodata.json
+++ b/inst/app.crunch.io/api/geodata.json
@@ -23,6 +23,16 @@
             "owner_id": "8e01e9f7a8e944a7a2c88e50c2a2997d",
             "id": "0001",
             "metadata": { }
+        },
+        "https://app.crunch.io/api/geodata/duplicate_prop/": {
+            "description": "This geo has duplicate properties",
+            "created": "2015-12-07T23:49:19.566000+00:00",
+            "name": "Duplicate properties",
+            "location": "https://s.crunch.io/some/wrong/duplicate_prop.topojson",
+            "format": "topojson",
+            "owner_id": "8e01e9f7a8e944a7a2c88e50c2a2997d",
+            "id": "0002",
+            "metadata": { }
         }
     },
     "template": "{\"body\": {\"tag\": \"<string>\", \"location\": \"<string>\", \"created\": \"<string>\", \"name\": \"<string>\", \"description\": \"<string>\"}, \"element\": \"shoji:entity\"}"

--- a/inst/app.crunch.io/api/geodata/duplicate_prop.json
+++ b/inst/app.crunch.io/api/geodata/duplicate_prop.json
@@ -1,0 +1,58 @@
+{
+    "element": "shoji:entity",
+    "self": "https://app.crunch.io/api/geodata/duplicate_prop/",
+    "description": "Details for a type of geodata",
+    "body": {
+        "name": "Duplicate properties",
+        "description": "This geo has duplicate properties",
+        "location": "https://s.crunch.io/some/wrong/duplicate_prop.topojson",
+        "format": "topojson",
+        "metadata": {
+            "status": "success",
+            "properties": {
+                "first_name": [
+                    "w",
+                    "n",
+                    "x",
+                    "b",
+                    "q",
+                    "s",
+                    "l",
+                    "v",
+                    "y",
+                    "m",
+                    "t",
+                    "e",
+                    "z",
+                    "k",
+                    "i",
+                    "h",
+                    "c"
+                ],
+                "second_name": [
+                    "w",
+                    "n",
+                    "x",
+                    "b",
+                    "q",
+                    "s",
+                    "l",
+                    "v",
+                    "y",
+                    "m",
+                    "t",
+                    "e",
+                    "z",
+                    "k",
+                    "i",
+                    "h",
+                    "c"
+                ],
+                "different_one": [
+                    "totally",
+                    "different"
+                ]
+            }
+        }
+    }
+}

--- a/inst/app.crunch.io/api/geodata/no_metadata.json
+++ b/inst/app.crunch.io/api/geodata/no_metadata.json
@@ -1,0 +1,11 @@
+{
+    "element": "shoji:entity",
+    "self": "https://app.crunch.io/api/geodata/no_metadata/",
+    "description": "Details for a type of geodata",
+    "body": {
+        "name": "Sans metadata (broken but possible state)",
+        "location": "https://s.crunch.io/some/wrong/path.geojson",
+        "format": "topojson",
+        "metadata": {}
+    }
+}

--- a/man/addGeoMetadata.Rd
+++ b/man/addGeoMetadata.Rd
@@ -4,19 +4,23 @@
 \alias{addGeoMetadata}
 \title{Add geodata metadata to a crunch variable}
 \usage{
-addGeoMetadata(variable)
+addGeoMetadata(variable, ...)
 }
 \arguments{
 \item{variable}{a Crunch variable to use for matching. This must be either
 a text or a categorical variable.}
+
+\item{...}{arguments passed on to \code{\link[=matchCatToFeat]{matchCatToFeat()}} for example a set of
+available geographic features as \code{all_features} if you want to limit the
+number of features to be considered.}
 }
 \value{
-a \code{[CrunchGeography]} object that can be assigned into \code{geo(variable)}
+a \code{\link{CrunchGeography}} object that can be assigned into \code{geo(variable)}
 }
 \description{
 If the variable matches a single geographic shapefile hosted by crunch,
-\code{addGeoMetadata} will make the appropriate \code{[CrunchGeography]} to add to a
-variable's \code{geo()} metadata. It matches based on how well the contents of the
+\code{addGeoMetadata} will make the appropriate \code{\link{CrunchGeography}} to add to a
+variable's \code{\link[=geo]{geo()}} metadata. It matches based on how well the contents of the
 variable match the feature properties that are in each shapefile.
 }
 \details{
@@ -26,7 +30,7 @@ highest matching score, the first one will be used.
 If more than one geographic shapefile has the same highest matching score, an
 error will be printed listing the geographic shapefiles that matched.
 Information from this error can be used to setup an appropriate
-\code{[CrunchGeography]} by hand to connect a variable with the metadata needed.
+\code{\link{CrunchGeography}} by hand to connect a variable with the metadata needed.
 }
 \examples{
 \dontrun{

--- a/man/addGeoMetadata.Rd
+++ b/man/addGeoMetadata.Rd
@@ -11,13 +11,25 @@ addGeoMetadata(variable)
 a text or a categorical variable.}
 }
 \value{
-a CrunchGeography object that can be assigned into \code{geo(variable)}
+a \code{[CrunchGeography]} object that can be assigned into \code{geo(variable)}
 }
 \description{
-Add geodata metadata to a crunch variable
+If the variable matches a single geographic shapefile hosted by crunch,
+\code{addGeoMetadata} will make the appropriate \code{[CrunchGeography]} to add to a
+variable's \code{geo()} metadata. It matches based on how well the contents of the
+variable match the feature properties that are in each shapefile.
+}
+\details{
+If more than one property of the same geographic shapefile has the same
+highest matching score, the first one will be used.
+
+If more than one geographic shapefile has the same highest matching score, an
+error will be printed listing the geographic shapefiles that matched.
+Information from this error can be used to setup an appropriate
+\code{[CrunchGeography]} by hand to connect a variable with the metadata needed.
 }
 \examples{
 \dontrun{
-geo(ds$state) <- addGeoMetadata("state", data=ds)
+geo(ds$state) <- addGeoMetadata(ds$state)
 }
 }

--- a/tests/testthat/test-geo.R
+++ b/tests/testthat/test-geo.R
@@ -8,34 +8,34 @@ with_mock_crunch({
         expect_equal(geo_data$feature_key, "properties.location")
         expect_equal(geo_data$match_field, "name")
         expect_equal(geo_data$geodatum,
-            "https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/")
+                     "https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/")
     })
-
+    
     test_that("is.Geodata", {
         expect_true(is.Geodata(Geodata(crGET("https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/"))))
     })
-
+    
     test_that("if there is no geography on a variable, geo() returns null", {
         expect_null(geo(ds$gender))
     })
-
+    
     test_that("can remove a geo association", {
         expect_PATCH(geo(ds$location) <- NULL,
                      'https://app.crunch.io/api/datasets/1/variables/location/',
                      '{"element":"shoji:entity","body":{"view":{"geodata":[]}}}')
     })
-
+    
     test_that("we can update individual fiels of the geography", {
         expect_PATCH(geo(ds$location)$feature_key <- "properties.location2",
                      'https://app.crunch.io/api/datasets/1/variables/location/',
                      '{"view":{"geodata":[{"geodatum":"https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/"',
                      ',"feature_key":"properties.location2","match_field":"name"}]}}'
-                     )
+        )
         expect_PATCH(geo(ds$location)$match_field <- "name2",
                      'https://app.crunch.io/api/datasets/1/variables/location/',
                      '{"view":{"geodata":[{"geodatum":"https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/"',
                      ',"feature_key":"properties.location","match_field":"name2"}]}}'
-                     )
+        )
         expect_PATCH(geo(ds$location)$geodatum <- "https://app.crunch.io/api/geodata/newone/",
                      'https://app.crunch.io/api/datasets/1/variables/location/',
                      '{"view":{"geodata":[{"geodatum":"https://app.crunch.io/api/geodata/newone/"',
@@ -53,30 +53,45 @@ with_mock_crunch({
                      ',"feature_key":"properties.location","match_field":"name"}]}}'
         )
     })
-
+    
     avail_features <- availableGeodataFeatures()
+    # make up new features to simulate a situation where multiple 
+    # geographies match
+    # double the geos
+    new_features <- avail_features
+    new_features$property <- paste0(new_features$property, "_new")
+    new_features$geodatum <- paste0(new_features$geodatum, "_new")
+    lots_o_features <- rbind(avail_features, new_features)
+    # triple the geos
+    new_features$property <- paste0(new_features$property, "_new")
+    new_features$geodatum <- paste0(new_features$geodatum, "_new")
+    lots_n_lots_o_features <- rbind(lots_o_features, new_features)
+    
     guesses <- c("foo", "bar", "Scotland", "North", "Midlands", "London")
+    
     test_that("availableFeatures", {
         expect_is(avail_features, "data.frame")
         expect_equal(dim(avail_features), c(51, 6))
         expect_equal(as.character(avail_features$value),
                      c(# GB Regions geodatum
-                       "UKH", "UKI", "UKL", "UKF", "UKJ", "UKC", "East",
-                       "London", "Wales", "Scotland", "Northern Ireland",
-                       "Midlands", "South", "North",
-                       # new one geodatum
-                       "test", 
-                       # Duplicate properties geodatum
-                       rep(c("w", "n", "x", "b", "q", "s", "l", "v", "y", "m",
-                             "t", "e", "z", "k", "i", "h", "c"), 2),
-                       "totally", "different"))
-
+                         "UKH", "UKI", "UKL", "UKF", "UKJ", "UKC", "East",
+                         "London", "Wales", "Scotland", "Northern Ireland",
+                         "Midlands", "South", "North",
+                         # new one geodatum
+                         "test", 
+                         # Duplicate properties geodatum
+                         rep(c("w", "n", "x", "b", "q", "s", "l", "v", "y", "m",
+                               "t", "e", "z", "k", "i", "h", "c"), 2),
+                         "totally", "different"))
+        
     })
+    
     test_that("scoreCatToFeat", {
         # check the score for guesses and mock available features is accurate
         features <- subset(avail_features, property == "name")$value
         expect_equal(scoreCatToFeat(features, guesses), 0.4)
     })
+    
     test_that("matchCatToFeat", {
         # There should be only one match, and it should be on property.name
         matches <- matchCatToFeat(guesses, all_features = avail_features)
@@ -85,7 +100,65 @@ with_mock_crunch({
         expect_equal(matches$value, 0.4)
         expect_equal(as.character(matches$property), "name")
     })
-
+    
+    test_that("multiMatchHelper deals with multiple geo features gracefully.", {
+        matches <- matchCatToFeat(guesses, all_features = lots_o_features)
+        match_msg <- multiMatchHelper(matches, "name", "var")
+        expect_length(match_msg, 11)
+        expect_equal(paste0(match_msg, collapse = ""),
+                     paste0("There is more than one possible match. You will ",
+                            "need to specify the geography manually using one of ",
+                            "the following CrunchGeographies:\n",
+                            "To add the geography: GB Regions\n",
+                            "matched to the property: name\n",
+                            "set the variable's geographic mapping with ",
+                            "following:\n",
+                            "geo(var) <- CrunchGeography(geodatum='https",
+                            "://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/',",
+                            " feature_key='properties.name',\n",
+                            "                   match_field='name')\n\n",
+                            "To add the geography: GB Regions\n",
+                            "matched to the property: name_new\n",
+                            "set the variable's geographic mapping with ",
+                            "following:\n",
+                            "geo(var) <- CrunchGeography(geodatum='https",
+                            "://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/_new',",
+                            " feature_key='properties.name_new',\n",
+                            "                   match_field='name')\n\n"))
+        # has three features
+        matches <- matchCatToFeat(guesses, all_features = lots_n_lots_o_features)
+        match_msg <- multiMatchHelper(matches, "name", "var")
+        expect_length(match_msg, 15)
+        expect_equal(paste0(match_msg, collapse = ""),
+                     paste0("There is more than one possible match. You will ",
+                            "need to specify the geography manually using one of ",
+                            "the following CrunchGeographies:\n",
+                            "To add the geography: GB Regions\n",
+                            "matched to the property: name\n",
+                            "set the variable's geographic mapping with ",
+                            "following:\n",
+                            "geo(var) <- CrunchGeography(geodatum='https",
+                            "://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/',",
+                            " feature_key='properties.name',\n",
+                            "                   match_field='name')\n\n",
+                            "To add the geography: GB Regions\n",
+                            "matched to the property: name_new\n",
+                            "set the variable's geographic mapping with ",
+                            "following:\n",
+                            "geo(var) <- CrunchGeography(geodatum='https",
+                            "://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/_new',",
+                            " feature_key='properties.name_new',\n",
+                            "                   match_field='name')\n\n",
+                            "To add the geography: GB Regions\n",
+                            "matched to the property: name_new_new\n",
+                            "set the variable's geographic mapping with ",
+                            "following:\n",
+                            "geo(var) <- CrunchGeography(geodatum='https",
+                            "://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/_new_new',",
+                            " feature_key='properties.name_new_new',\n",
+                            "                   match_field='name')\n\n"))
+    })
+    
     test_that("addGeoMetadata", {
         # full run of adding geometadata including guessing the geodata to use
         geo_to_add <- addGeoMetadata(ds$location)
@@ -93,23 +166,55 @@ with_mock_crunch({
         expect_equal(geo_to_add$feature_key, "properties.name")
         expect_equal(geo_to_add$match_field, "name")
         expect_equal(geo_to_add$geodatum,
-        "https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/")
+                     "https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/")
     })
- 
+    
     test_that("addGeoMetadata adds the first property if more than one matches", {
         # if there is more than one property on a single geodatum that matches, 
         # just use the first property.
         expect_warning(geo_to_add <- addGeoMetadata(ds$textVar), 
                        paste0("The geodatum ", dQuote("Duplicate properties"),
-                             " has multiple properties that match the variable \\(",
-                             dQuote("first_name"), " and ", dQuote("second_name"),
-                             "\\). Using ", dQuote("first_name"), "\\."))
+                              " has multiple properties that match the variable \\(",
+                              dQuote("first_name"), " and ", dQuote("second_name"),
+                              "\\). Using ", dQuote("first_name"), "\\."))
         expect_is(geo_to_add, "CrunchGeography")
         expect_equal(geo_to_add$feature_key, "properties.first_name")
         expect_equal(geo_to_add$match_field, "name")
         expect_equal(geo_to_add$geodatum,
                      "https://app.crunch.io/api/geodata/duplicate_prop/")
-    })   
+    })
+    
+    test_that("addGeoMetadata tries to help if there are multiple matches", {
+        # if there is more than one property on a single geodatum that matches, 
+        # just use the first property.
+        expect_error(geo_to_add <- addGeoMetadata(ds$location,
+                                                  all_features = lots_o_features),
+                     paste0(
+                         "There is more than one possible match. You will ",
+                         "need to specify the geography manually using one of ",
+                         "the following CrunchGeographies:\n",
+                         "To add the geography: GB Regions\n",
+                         "matched to the property: name\n",
+                         "set the variable's geographic mapping with ",
+                         "following:\n",
+                         "geo(ds$location) <- CrunchGeography(geodatum='https",
+                         "://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/',",
+                         " feature_key='properties.name',\n",
+                         "                   match_field='name')\n\n",
+                         "To add the geography: GB Regions\n",
+                         "matched to the property: name_new\n",
+                         "set the variable's geographic mapping with ",
+                         "following:\n",
+                         "geo(ds$location) <- CrunchGeography(geodatum='https",
+                         "://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/_new',",
+                         " feature_key='properties.name_new',\n",
+                         "                   match_field='name')\n\n"
+                     ),
+                     fixed = TRUE)
+        
+    })
+    
+    
     
     test_that("addGeoMetadata input validation", {
         # adding dQuote("ds$not_a_var") to error string inexplicably doesn't
@@ -117,23 +222,23 @@ with_mock_crunch({
         expect_error(addGeoMetadata(ds$not_a_var),
                      ".* must be a Crunch Variable.")
         expect_error(addGeoMetadata(ds$starttime),
-             paste0("The variable ", dQuote("ds\\$starttime"),
-             " is neither a categorical or text variable\\."))
+                     paste0("The variable ", dQuote("ds\\$starttime"),
+                            " is neither a categorical or text variable\\."))
         expect_error(addGeoMetadata(ds$gender),
-             paste0("None of the geographies match at all. Either the variable is",
-             " wrong, or Crunch doesn't yet have geodata for this variable."))
+                     paste0("None of the geographies match at all. Either the variable is",
+                            " wrong, or Crunch doesn't yet have geodata for this variable."))
     })
-
+    
     test_that("CrunchGeography show methods", {
         expect_output(geo_data,
-                      paste0("CrunchGeography metadata for variable \n",
-                     "geodatum name: 		GB Regions\n",
-                     "geodatum description: 	These are the GB regions\n",
-                     "geodatum url: 		https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/\n",
-                     "feature_key: 		properties.location\n",
-                     "match_field: 		name"))
+                      paste0("CrunchGeography metadata for variable \\\n",
+                             "geodatum name: 		GB Regions\\\n",
+                             "geodatum description: 	These are the GB regions\\\n",
+                             "geodatum url: 		https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/\\\n",
+                             "feature_key: 		properties.location\\\n",
+                             "match_field: 		name"))
     })
-
+    
     test_that("Geodata methods", {
         gd <- Geodata(crGET(geo_data$geodatum))
         expect_is(gd, "Geodata")
@@ -166,49 +271,50 @@ with_test_authentication({
     #                 "location" = "https://s.crunch.io/geodata/crunch-io/cb_2015_us_region_20m.topojson",
     #                 "owner_id" = "00002")
     # crPOST("http://local.crunch.io:8080/api/geodata/", body=toJSON(payload))
-
+    
     geo_ds <- newDataset(df)
     test_that("Can match and set geodata on a text variable", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
         geo_ds$region <- rep(c("South", "West", "West", "South", "West"), 4)
         expect_silent(geo_ds$region <- addGeoMetadata(geo_ds$region))
         expect_output(geo(geo_ds$region),
-                      paste0("geodatum name: 		US Census Regions\n",
-                      "geodatum description: 	Census regions\n",
-                      "geodatum url: 		.*\n", # the geodatum id will change, so the url will change.
-                      "feature_key: 		properties.name\n",
-                      "match_field: 		name"))
+                      paste0("geodatum name: 		US Census Regions\\\n",
+                             "geodatum description: 	Census regions\\\n",
+                             "geodatum url: 		.*\\\n", # the geodatum id will change, so the url will change.
+                             "feature_key: 		properties.name\\\n",
+                             "match_field: 		name"))
     })
-
+    
     test_that("Can match and set geodata on a categorical variable", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
         geo_ds$region2 <- factor(rep(c("South", "West", "West", "South", "West"), 4))
         expect_silent(geo_ds$region2 <- addGeoMetadata(geo_ds$region2))
         expect_output(geo(geo_ds$region2),
-                      paste0("geodatum name: 		US Census Regions\n",
-                      "geodatum description: 	Census regions\n",
-                      "geodatum url: 		.*\n", # the geodatum id will change, so the url will change.
-                      "feature_key: 		properties.name\n",
-                      "match_field: 		name"))
+                      paste0("geodatum name: 		US Census Regions\\\n",
+                             "geodatum description: 	Census regions\\\n",
+                             "geodatum url: 		.*\\\n", # the geodatum id will change, so the url will change.
+                             "feature_key: 		properties.name\\\n",
+                             "match_field: 		name"))
     })
-
+    
     geo_ds$state <- rep(c("Alabama", "Alaska", "Arizona", "Arkansas", "California"), 4)
     test_that("There is an error if more than one geography matches", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
         expect_error(geo_ds$state <- addGeoMetadata(geo_ds$state),
-                     "There is more than one possible match. Please specify the geography manually.*")
+                     paste0("There is more than one possible match. You will ",
+                     "need to specify the geography manually using one of .*"))
     })
     test_that("can manually set a geography after a failed match", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
         avail_geo <- availableGeodata()
         new_geo <- CrunchGeography(geodatum = urls(avail_geo["US States Topojson"]),
-                                        feature_key = "name",
-                                        match_field = "name")
+                                   feature_key = "name",
+                                   match_field = "name")
         geo_ds$state <- new_geo
         expect_is(geo(geo_ds$state), "CrunchGeography")
         expect_identical(geo(geo_ds$state), new_geo)
     })
-
+    
     test_that("can remove a geo association", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
         expect_silent(geo(geo_ds$state) <- NULL)


### PR DESCRIPTION
`addGeoMetadata` now will automatically match when a geodatum has duplicate properties.