### PR TITLE
Refresh a dataset entity without requesting a dataset catalog

### DIFF
--- a/R/get-datasets.R
+++ b/R/get-datasets.R
@@ -128,17 +128,23 @@ loadDataset <- function (dataset, kind=c("active", "all", "archived"), project=N
         if (is.null(dataset)) {
             ## Check to see if this is a URL, in which case, GET it
             if (startsWith(dsname, "http")) {
-                dataset <- CrunchDataset(crGET(dsname))
-                tuple(dataset) <- DatasetTuple(entity_url=self(dataset),
-                    body=dataset@body,
-                    index_url=shojiURL(dataset, "catalogs", "parent"))
-                return(dataset)
+                return(loadDatasetFromURL(dsname))
             }
             halt(dQuote(dsname), " not found")
         }
     }
     return(entity(dataset))
 }
+
+loadDatasetFromURL <- function (url) {
+    ## Load dataset without touching a dataset catalog
+    dataset <- CrunchDataset(crGET(url))
+    tuple(dataset) <- DatasetTuple(entity_url=self(dataset),
+        body=dataset@body,
+        index_url=shojiURL(dataset, "catalogs", "parent"))
+    return(dataset)
+}
+
 
 #' Delete a dataset from the dataset list
 #'

--- a/inst/app.crunch.io/api/datasets/1.json
+++ b/inst/app.crunch.io/api/datasets/1.json
@@ -6,7 +6,7 @@
     "body": {
         // In reality, body has attributes found in the tuple too
         "owner": "https://app.crunch.io/api/users/user1/",
-        "id": "dataset1",
+        "id": "511a7c49778030653aab5963",
         "streaming": "no"
     },
     "catalogs": {

--- a/inst/app.crunch.io/api/datasets/1streaming.json
+++ b/inst/app.crunch.io/api/datasets/1streaming.json
@@ -6,7 +6,7 @@
     "body": {
         // In reality, body has attributes found in the tuple too
         "owner": "https://app.crunch.io/api/users/user1/",
-        "id": "dataset1",
+        "id": "5405313ab82d4d753bcf42f01d2e28f8",
         "streaming": "streaming"
     },
     "catalogs": {

--- a/man/refresh.Rd
+++ b/man/refresh.Rd
@@ -26,5 +26,5 @@ manipulate them, but some operations cause the local version to diverge from
 the version on the server. For instance, someone else may have
 modified the dataset you're working on, or maybe
 you have modified a variable outside of the context of its dataset.
-refresh() allows you to get back in sync.
+\code{refresh()} allows you to get back in sync.
 }

--- a/tests/testthat/test-dataset-entity.R
+++ b/tests/testthat/test-dataset-entity.R
@@ -253,6 +253,19 @@ with_mock_crunch({
         expect_identical(ds, refresh(ds))
     })
 
+    test_that("dataset refresh doesn't GET dataset catalog", {
+        with(temp.option(httpcache.log=""), {
+            logs <- capture.output({
+                d2 <- refresh(ds)
+            })
+        })
+        in_logs <- function (str, loglines) {
+            any(grepl(str, loglines, fixed=TRUE))
+        }
+        expect_false(in_logs("HTTP GET https://app.crunch.io/api/datasets/ 200", logs))
+        expect_true(in_logs("CACHE DROP ^https://app[.]crunch[.]io/api/datasets/", logs))
+    })
+
     test_that("Dataset settings", {
         expect_false(settings(ds)$viewers_can_export)
         expect_true(settings(ds)$viewers_can_change_weight)
@@ -336,7 +349,7 @@ with_test_authentication({
         test_that("Can set (and unset) startDate", {
             startDate(ds) <- "1985-11-05"
             expect_identical(startDate(ds), "1985-11-05")
-            expect_identical(startDate(refresh(ds)), "1985-11-05")
+            expect_identical(startDate(refresh(ds)), "1985-11-05T00:00:00")
             startDate(ds) <- NULL
             expect_null(startDate(ds))
             expect_null(startDate(refresh(ds)))
@@ -344,7 +357,7 @@ with_test_authentication({
         test_that("Can set (and unset) endDate", {
             endDate(ds) <- "1985-11-05"
             expect_identical(endDate(ds), "1985-11-05")
-            expect_identical(endDate(refresh(ds)), "1985-11-05")
+            expect_identical(endDate(refresh(ds)), "1985-11-05T00:00:00")
             endDate(ds) <- NULL
             expect_null(endDate(ds))
             expect_null(endDate(refresh(ds)))


### PR DESCRIPTION
Drop the catalog cache, but refresh the entity object with just the entity.