### PR TITLE
Fixes a bug where a categorical variable could be confused with the selected dimension of a Multiple Response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## crunch 1.19.1
 * `refresh()` for Datasets is now more efficient
+* fixed a bug where CrunchCubes with categorical variables that had categories "Selected", "Not selected", and "No data" might not display correctly. 
 
 ## crunch 1.19.0
 

--- a/R/cube-dims.R
+++ b/R/cube-dims.R
@@ -122,25 +122,19 @@ setMethod("[", "CubeDims", function (x, i, ...) {
 
 is.selectedDimension <- function (dims) {
     is.it <- function (x, dim, MRaliases) {
-        x$type == "categorical" && length(dim$name) == 3 &&
-            dim$name[1] == "Selected" && x$alias %in% MRaliases
+        x$alias %in% MRaliases &&
+            x$type == "categorical" &&
+            length(dim$name) == 3 &&
+            dim$name[1] == "Selected"
     }
-    # We only need to check if the categories are the magical Selected 
+    vars <- variables(dims)
+    # We only need to check if the categories are the magical Selected
     # categories if there is an MR somewhere with the same alias
-    MRaliases <- vapply(index(variables(dims)), function (var) {
-        # return the alias only for multiple_response variables
-        if (!is.null(var$type) && var$type == "multiple_response") {
-            return(var$alias)
-        } else {
-            return(NA_character_)
-        }
-    }, character(1))
-    # remove blank aliases so we only have the MR aliases
-    MRaliases <- MRaliases[!is.na(MRaliases)]
-    
+    MRaliases <- aliases(vars)[types(vars) == "multiple_response"]
+
     # determine which dimensions are selected MR dimensions
-    selecteds <- mapply(is.it, x=index(variables(dims)), dim=dims@.Data, 
-                        MoreArgs = list(MRaliases = MRaliases))
+    selecteds <- mapply(is.it, x=index(vars), dim=dims@.Data,
+                        MoreArgs=list(MRaliases=MRaliases))
     names(selecteds) <- dims@names
     return(selecteds)
 }

--- a/tests/testthat/cubes/univariate-categorical-like-selected.json
+++ b/tests/testthat/cubes/univariate-categorical-like-selected.json
@@ -1,0 +1,72 @@
+{
+    "element": "shoji:view",
+    "self": "https://stable.crunch.io/api/datasets/ab64eee04efb43d4ae9c13e0e71468c4/cube/?query=%7B%22dimensions%22%3A%5B%7B%22variable%22%3A%22https%3A%2F%2Fstable.crunch.io%2Fapi%2Fdatasets%2Fab64eee04efb43d4ae9c13e0e71468c4%2Fvariables%2F000006%2F%22%7D%5D%2C%22measures%22%3A%7B%22count%22%3A%7B%22function%22%3A%22cube_count%22%2C%22args%22%3A%5B%5D%7D%7D%2C%22weight%22%3Anull%7D&filter=%7B%7D",
+    "value": {
+        "query": {
+            "measures": {
+                "count": {
+                    "function": "cube_count",
+                    "args": []
+                }
+            },
+            "dimensions": [{
+                "variable": "https://stable.crunch.io/api/datasets/ab64eee04efb43d4ae9c13e0e71468c4/variables/000006/"
+            }],
+            "weight": null
+        },
+        "query_environment": {
+            "filter": []
+        },
+        "result": {
+            "dimensions": [{
+                "references": {
+                    "alias": "selected_like",
+                    "name": "selected_like"
+                },
+                "derived": false,
+                "type": {
+                    "ordinal": false,
+                    "class": "categorical",
+                    "categories": [{
+                        "numeric_value": 1,
+                        "missing": false,
+                        "id": 1,
+                        "name": "Selected"
+                    }, {
+                        "numeric_value": 2,
+                        "missing": false,
+                        "id": 2,
+                        "name": "Not selected"
+                    }, {
+                        "numeric_value": null,
+                        "missing": true,
+                        "id": -1,
+                        "name": "No Data"
+                    }]
+                }
+            }],
+            "missing": 5,
+            "measures": {
+                "count": {
+                    "data": [10, 5, 0],
+                    "n_missing": 5,
+                    "metadata": {
+                        "references": {},
+                        "derived": true,
+                        "type": {
+                            "integer": true,
+                            "missing_rules": {},
+                            "missing_reasons": {
+                                "No Data": -1
+                            },
+                            "class": "numeric"
+                        }
+                    }
+                }
+            },
+            "element": "crunch:cube",
+            "counts": [10, 5, 0],
+            "n": 15
+        }
+    }
+}

--- a/tests/testthat/test-cube-basic.R
+++ b/tests/testthat/test-cube-basic.R
@@ -1,9 +1,9 @@
 context("Basic cube methods")
 
-v7 <- v7_ifany <- v7_always <- loadCube("cubes/univariate-categorical.json")
+v7 <- v7_ifany <- v7_always <- loadCube(test_path("cubes/univariate-categorical.json"))
 v7_ifany@useNA <- "ifany"
 v7_always@useNA <- "always"
-v4_x_v7 <- v4_x_v7_ifany <- v4_x_v7_always <- loadCube("cubes/cat-x-cat.json")
+v4_x_v7 <- v4_x_v7_ifany <- v4_x_v7_always <- loadCube(test_path("cubes/cat-x-cat.json"))
 v4_x_v7_ifany@useNA <- "ifany"
 v4_x_v7_always@useNA <- "always"
 
@@ -59,6 +59,19 @@ test_that("Cube print method", {
               "v4  C D E",
               "  B 5 3 2",
               "  C 5 2 3", sep="\n"))
+})
+
+selected_subvar <- loadCube(test_path("cubes/univariate-categorical-like-selected.json"))
+
+test_that("Categorical with categories Selected, Not selected", {
+    # when detecting if a dimension is selected, we look at the categories. This
+    # breaks if one tries to display a categorical that just so happens to have
+    # Selected and Not selected as categories
+    expect_output(selected_subvar,
+                  paste("selected_like",
+                        "    Selected Not selected ",
+                        "          10            5 ",
+                        sep="\n"))
 })
 
 with_mock_crunch({

--- a/tests/testthat/test-cube-mr.R
+++ b/tests/testthat/test-cube-mr.R
@@ -10,7 +10,7 @@ alldims <- list(
         "I don't mind paying more for products that are good for the environment")
 )
 
-mr_x_cat_wt <- loadCube("cubes/selected-crosstab-4.json")
+mr_x_cat_wt <- loadCube(test_path("cubes/selected-crosstab-4.json"))
 
 test_that("properties of a cube with for as_selected x cat: it looks 2D", {
     expect_equal(dim(mr_x_cat_wt), c(6L, 3L))


### PR DESCRIPTION
For cube methods with multiple response variables, we need to identify which dimension is the selected dimension (generally represented as a categorical with the categories Selected, Not selected, and No data). The method to determine if a dimension was selected was overly aggressive, and would identify categorical variables that had those categories as a selected dimension, which broke a number of display methods for those categorical variables.

This change only marks a dimension as selected if it has the magic Selected, Not selected, No data categories and if its alias matches a multiple response dimension. This should be true of all multiple response using the `as_selected` zz9 function.

In testing, I added some `test_path()`s around cube fixtures for easier interactive testing. 