### PR TITLE
Clean up for Subtotals and Headings / Transforms

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -309,6 +309,10 @@ Insertions <- GenericConstructor("Insertions")
 #' @export
 setClass("Insertion", contains="AbstractCategory")
 
+# Make a constructor with a user-facing and package internal versions instead of 
+# simply setMethod("initialize", "Insertions") so that the user-facing version
+# preforms validation, but the internal version does not. This is needed for 
+# making heterogenous insertions that include classes Subtotal and Heading.
 #' @rdname Insertions
 #' @export
 Insertion <- function (...) {

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -309,7 +309,7 @@ Insertions <- GenericConstructor("Insertions")
 #' @export
 setClass("Insertion", contains="AbstractCategory")
 
-# Make a constructor with a user-facing and package internal versions instead of 
+# Make a constructor with user-facing and package internal versions instead of 
 # simply setMethod("initialize", "Insertions") so that the user-facing version
 # preforms validation, but the internal version does not. This is needed for 
 # making heterogenous insertions that include classes Subtotal and Heading.

--- a/R/cube-dims.R
+++ b/R/cube-dims.R
@@ -36,7 +36,7 @@ cubeVarReferences <- function (x) {
     tuple <- x$references
     tuple$type <- x$type$class
     if (tuple$type == "enum" && "subreferences" %in% names(tuple)) {
-        tuple$type <- "multiple_response"
+        tuple$type <- "subvariable_items"
     }
     tuple$categories <- x$type$categories
     return(tuple)
@@ -145,7 +145,7 @@ is.selectedDimension <- function (dims) {
     vars <- variables(dims)
     # We only need to check if the categories are the magical Selected
     # categories if there is an MR somewhere with the same alias
-    MRaliases <- aliases(vars)[types(vars) == "multiple_response"]
+    MRaliases <- aliases(vars)[types(vars) == "subvariable_items"]
 
     # determine which dimensions are selected MR dimensions
     selecteds <- mapply(is.it, x=index(vars), dim=dims@.Data,

--- a/R/cube-transforms.R
+++ b/R/cube-transforms.R
@@ -198,12 +198,11 @@ setMethod("transforms<-", c("CrunchCube", "list"), function (x, value) {
              "names of the cube.")
     }
 
-    
     # replace the transforms for each dimension
     dims <- CubeDims(lapply(dimnames, function (dim_name) {
         dim_out <- dims[[dim_name]]
         if (dim_name %in% names(value)) {
-            # grab the proper insertions, make sure they are proper Insertions
+            # grab the matching insertions, make sure they are proper Insertions
             # and then add them to the dimensions to return.
             one_trans <- value[[dim_name]]
             one_trans$insertions <- Insertions(

--- a/R/cube-transforms.R
+++ b/R/cube-transforms.R
@@ -165,8 +165,9 @@ setMethod("transforms", "VariableCatalog", function (x) {
         return(NULL)
     }
     transes_out <- lapply(transes, function (i) {
-        # if insertions are null return NULL
         # TODO: when other transforms are implemented, this should check those too.
+
+        # if insertions are null return NULL
         if (is.null(i$insertions) || length(i$insertions) == 0) {
             return(NULL)
         }
@@ -193,9 +194,11 @@ setMethod("transforms<-", c("CrunchCube", "list"), function (x, value) {
     dimnames <- names(dims)
     
     # check if the names of the dimensions and the names of the transforms line up
-    if (any(!names(value) %in% dimnames)) {
-        halt("The names of the transforms supplied to not match the dimension ",
-             "names of the cube.")
+    if (any(!(names(value) %in% dimnames))) {
+        halt("The names of the transforms supplied (", 
+             serialPaste(dQuote(names(value)))
+             ,") to not match the dimension names (",
+             serialPaste(dQuote(dimnames)) ,") of the cube.")
     }
 
     # replace the transforms for each dimension

--- a/R/pretty-print.R
+++ b/R/pretty-print.R
@@ -71,6 +71,11 @@ prettyPrint2d <- function (array, row_styles = NULL, col_styles = NULL) {
 
 pad <- function (n, char = " ") strrep(char, n)
 
+# available in a more efficient implementation, with type checking in R>=3.3.0
+# TODO: when it's reasonable / other requirements require R>=3.3.0 switch to R's
+# implementation
+strrep <- function(char, n) paste0(rep(char, n), collapse = "")
+
 # Remove NAs from crayon styled strings
 nonas <- function (string, to_remove = c("NA")) {
     for (rm in to_remove) {

--- a/R/show.R
+++ b/R/show.R
@@ -53,10 +53,19 @@ showAbsCategories <- function (x) do.call("rbind", lapply(x, showAbsCategory))
 
 showInsertion <- function (x) {
     df_out <- data.frame(anchor=anchor(x), name=name(x),
-               func=func(x),
-               args=serialPaste(args(x)))
+               func=func(x), args=serialPaste(args(x)))
 }
-showInsertions <- function (x) do.call("rbind", lapply(x, showInsertion))
+showInsertions <- function (x) do.call("rbind", lapply(x, getShowContent))
+
+showSubtotalHeading <- function (x) {
+    # if anchor or args error because a categories object is not available to 
+    # translate from category names to ids, then show the names without error 
+    # for the show method only.
+    anchor <- tryCatch(anchor(x), error = function(e) {return(x$after)})
+    args <- tryCatch(args(x), error = function(e) {return(x$categories)})
+    df_out <- data.frame(anchor=anchor, name=name(x),
+                         func=func(x), args=serialPaste(args))
+}
 
 
 showCrunchVariableTitle <- function (x) {
@@ -288,6 +297,8 @@ setMethod("getShowContent", "AbstractCategory", showAbsCategory)
 setMethod("getShowContent", "AbstractCategories", showAbsCategories)
 setMethod("getShowContent", "Insertion", showInsertion)
 setMethod("getShowContent", "Insertions", showInsertions)
+setMethod("getShowContent", "Subtotal", showSubtotalHeading)
+setMethod("getShowContent", "Heading", showSubtotalHeading)
 setMethod("getShowContent", "CrunchVariable", showCrunchVariable)
 setMethod("getShowContent", "CategoricalArrayVariable",
     showCategoricalArrayVariable)

--- a/R/transform.R
+++ b/R/transform.R
@@ -61,8 +61,9 @@ getTransforms <- function (x) {
         inserts <- subtypeInsertions(inserts)
     }
     
-    # if insertions are null return NULL
     # TODO: when other transforms are implemented, this should check those too.
+
+    # if insertions are null return NULL
     if (is.null(inserts)) {
         return(NULL)
     }

--- a/R/transform.R
+++ b/R/transform.R
@@ -40,17 +40,26 @@ NULL
 getTransforms <- function (x) {
     var_entity <- entity(x)
     trans <- var_entity@body$view$transform
-
     if (is.null(trans) || length(trans) == 0) {
         return(NULL)
     }
 
-    # get the insertions
-    inserts <- Insertions(data=trans$insertions)
-    # subtype insertions so that Subtotal, Heading, etc. are their rightful selves
-    inserts <- subtypeInsertions(inserts)
+    if (is.null(trans$insertions) || length(trans$insertions) == 0) {
+        inserts <- NULL
+    } else {
+        inserts <- Insertions(data=trans$insertions)
+        # subtype insertions so that Subtotal, Heading, etc. are their rightful 
+        # selves
+        inserts <- subtypeInsertions(inserts)
+    }
     
-    trans_out <- Transforms(insertions = Insertions(data=inserts),
+    # if insertions are null return NULL
+    # TODO: when other transforms are implemented, this should check those too.
+    if (is.null(inserts)) {
+        return(NULL)
+    }
+    
+    trans_out <- Transforms(insertions = inserts,
                             categories = NULL,
                             elements = NULL)
     return(trans_out)

--- a/R/transform.R
+++ b/R/transform.R
@@ -14,12 +14,20 @@
 #' [Heading()][SubtotalsHeadings]) are the only type of transformations that are
 #' supported.
 #' 
-#' @section Setting transformations:
+#' @section Setting transformations on a variable:
 #' The `transforms(x) <- value` methods can be used to assign transformations 
-#' for a specific variable (this will not yet work on a CrunchCube). `value` 
+#' for a specific variable. `value` 
 #' must be a `Transforms` object. This allows you to set transformations on 
 #' categorical variables. These transformations will automatically show up in 
 #' any new CrunchCubes that contain this variable.
+#' 
+#' @section Setting transformations on a CrunchCube:
+#' The `transforms(x) <- value` methods can also be used to assign 
+#' transformations to a CrunchCube that has already been calculated. `value` 
+#' must be a named list of `Transforms` objects. The names of this list must 
+#' correspond to dimensions in the cube (those dimensions correspondences are 
+#' matched based on variable aliases). You don't have to provide an entry for
+#' each dimension, but any dimension you do provide will be overwritten fully.
 #' 
 #' @section Removing transformations:
 #' To remove transformations from a variable or CrunchCube, use 
@@ -34,7 +42,7 @@
 #' Transforms
 #' @param value For `[<-`, the replacement Transforms to insert
 #' @name Transforms
-#' @aliases transforms transforms<-
+#' @aliases transforms transforms<- 
 NULL
 
 getTransforms <- function (x) {

--- a/man/Transforms.Rd
+++ b/man/Transforms.Rd
@@ -7,6 +7,7 @@
 \alias{Transforms}
 \alias{transforms,CrunchCube-method}
 \alias{transforms,VariableCatalog-method}
+\alias{transforms<-,CrunchCube,list-method}
 \alias{transforms<-,CrunchCube,NULL-method}
 \alias{Transforms}
 \alias{transforms}
@@ -22,6 +23,8 @@ Transforms(..., data = NULL)
 \S4method{transforms}{CrunchCube}(x)
 
 \S4method{transforms}{VariableCatalog}(x)
+
+\S4method{transforms}{CrunchCube,list}(x) <- value
 
 \S4method{transforms}{CrunchCube,`NULL`}(x) <- value
 
@@ -63,13 +66,23 @@ Currently, \link{Insertions} (e.g. \link[=SubtotalsHeadings]{Subtotal()} and
 supported.
 }
 
-\section{Setting transformations}{
+\section{Setting transformations on a variable}{
 
 The \code{transforms(x) <- value} methods can be used to assign transformations
-for a specific variable (this will not yet work on a CrunchCube). \code{value}
+for a specific variable. \code{value}
 must be a \code{Transforms} object. This allows you to set transformations on
 categorical variables. These transformations will automatically show up in
 any new CrunchCubes that contain this variable.
+}
+
+\section{Setting transformations on a CrunchCube}{
+
+The \code{transforms(x) <- value} methods can also be used to assign
+transformations to a CrunchCube that has already been calculated. \code{value}
+must be a named list of \code{Transforms} objects. The names of this list must
+correspond to dimensions in the cube (those dimensions correspondences are
+matched based on variable aliases). You don't have to provide an entry for
+each dimension, but any dimension you do provide will be overwritten fully.
 }
 
 \section{Removing transformations}{

--- a/tests/testthat/cubes/catarray-with-transforms.json
+++ b/tests/testthat/cubes/catarray-with-transforms.json
@@ -1,0 +1,361 @@
+{
+  "element": "shoji:view",
+  "self": "/api/datasets/123/cube/?query=%7B%22dimensions%22%3A%5B%7B%22each%22%3A%22%2Fapi%2Fdatasets%123%2Fvariables%2F000001%2F%22%7D%2C%7B%22variable%22%3A%22%2Fapi%2Fdatasets%2F123%2Fvariables%2F000001%2F%22%7D%5D%2C%22measures%22%3A%7B%22count%22%3A%7B%22function%22%3A%22cube_count%22%2C%22args%22%3A%5B%5D%7D%7D%2C%22weight%22%3Anull%7D&filter=%7B%7D",
+  "value": {
+    "query": {
+      "measures": {
+        "count": {
+          "function": "cube_count",
+          "args": []
+        }
+      },
+      "dimensions": [
+        {
+          "each": "/api/datasets/123/variables/000001/"
+        },
+        {
+          "variable": "/api/datasets/123/variables/000001/"
+        }
+      ],
+      "weight": null
+    },
+    "query_environment": {
+      "filter": []
+    },
+    "result": {
+      "dimensions": [
+        {
+          "derived": true,
+          "references": {
+            "subreferences": [
+              {
+                "alias": "mr_1",
+                "name": "mr_1",
+                "view": {
+                  "show_counts": false,
+                  "column_width": null,
+                  "include_missing": false,
+                  "show_numeric_values": false
+                }
+              },
+              {
+                "alias": "mr_2",
+                "name": "mr_2",
+                "view": {
+                  "show_counts": false,
+                  "show_numeric_values": false,
+                  "include_missing": false,
+                  "column_width": null
+                }
+              },
+              {
+                "alias": "mr_3",
+                "name": "mr_3",
+                "view": {
+                  "show_counts": false,
+                  "show_numeric_values": false,
+                  "include_missing": false,
+                  "column_width": null
+                }
+              }
+            ],
+            "alias": "CA",
+            "name": "CA",
+            "view": {
+              "show_counts": false,
+              "transform": {
+                "insertions": [
+                  {
+                    "function": "subtotal",
+                    "args": [
+                      2,
+                      1
+                    ],
+                    "anchor": 1,
+                    "name": "A+B"
+                  }
+                ]
+              },
+              "include_missing": false,
+              "column_width": null
+            }
+          },
+          "type": {
+            "subtype": {
+              "class": "variable"
+            },
+            "elements": [
+              {
+                "id": 1,
+                "value": {
+                  "derived": false,
+                  "references": {
+                    "alias": "mr_1",
+                    "name": "mr_1",
+                    "view": {
+                      "show_counts": false,
+                      "column_width": null,
+                      "include_missing": false,
+                      "show_numeric_values": false
+                    }
+                  },
+                  "id": "000001",
+                  "type": {
+                    "ordinal": false,
+                    "class": "categorical",
+                    "categories": [
+                      {
+                        "numeric_value": 0,
+                        "selected": false,
+                        "id": 2,
+                        "missing": false,
+                        "name": "A"
+                      },
+                      {
+                        "numeric_value": 1,
+                        "selected": false,
+                        "id": 1,
+                        "missing": false,
+                        "name": "B"
+                      },
+                      {
+                        "numeric_value": null,
+                        "selected": false,
+                        "id": -1,
+                        "missing": true,
+                        "name": "No Data"
+                      }
+                    ]
+                  }
+                },
+                "missing": false
+              },
+              {
+                "id": 2,
+                "value": {
+                  "derived": false,
+                  "references": {
+                    "alias": "mr_2",
+                    "name": "mr_2",
+                    "view": {
+                      "show_counts": false,
+                      "show_numeric_values": false,
+                      "include_missing": false,
+                      "column_width": null
+                    }
+                  },
+                  "id": "000002",
+                  "type": {
+                    "ordinal": false,
+                    "class": "categorical",
+                    "categories": [
+                      {
+                        "numeric_value": 0,
+                        "selected": false,
+                        "id": 2,
+                        "missing": false,
+                        "name": "A"
+                      },
+                      {
+                        "numeric_value": 1,
+                        "selected": false,
+                        "id": 1,
+                        "missing": false,
+                        "name": "B"
+                      },
+                      {
+                        "numeric_value": null,
+                        "selected": false,
+                        "id": -1,
+                        "missing": true,
+                        "name": "No Data"
+                      }
+                    ]
+                  }
+                },
+                "missing": false
+              },
+              {
+                "id": 3,
+                "value": {
+                  "derived": false,
+                  "references": {
+                    "alias": "mr_3",
+                    "name": "mr_3",
+                    "view": {
+                      "show_counts": false,
+                      "show_numeric_values": false,
+                      "include_missing": false,
+                      "column_width": null
+                    }
+                  },
+                  "id": "000003",
+                  "type": {
+                    "ordinal": false,
+                    "class": "categorical",
+                    "categories": [
+                      {
+                        "numeric_value": 0,
+                        "selected": false,
+                        "id": 2,
+                        "missing": false,
+                        "name": "A"
+                      },
+                      {
+                        "numeric_value": 1,
+                        "selected": false,
+                        "id": 1,
+                        "missing": false,
+                        "name": "B"
+                      },
+                      {
+                        "numeric_value": null,
+                        "selected": false,
+                        "id": -1,
+                        "missing": true,
+                        "name": "No Data"
+                      }
+                    ]
+                  }
+                },
+                "missing": false
+              }
+            ],
+            "class": "enum"
+          }
+        },
+        {
+          "derived": false,
+          "references": {
+            "subreferences": [
+              {
+                "alias": "mr_1",
+                "name": "mr_1",
+                "view": {
+                  "show_counts": false,
+                  "show_numeric_values": false,
+                  "include_missing": false,
+                  "column_width": null
+                }
+              },
+              {
+                "alias": "mr_2",
+                "name": "mr_2",
+                "view": {
+                  "show_counts": false,
+                  "column_width": null,
+                  "include_missing": false,
+                  "show_numeric_values": false
+                }
+              },
+              {
+                "alias": "mr_3",
+                "name": "mr_3",
+                "view": {
+                  "show_counts": false,
+                  "column_width": null,
+                  "include_missing": false,
+                  "show_numeric_values": false
+                }
+              }
+            ],
+            "view": {
+              "show_counts": false,
+              "transform": {
+                "insertions": [
+                  {
+                    "function": "subtotal",
+                    "args": [
+                      2,
+                      1
+                    ],
+                    "anchor": 1,
+                    "name": "A+B"
+                  }
+                ]
+              },
+              "include_missing": false,
+              "column_width": null
+            },
+            "name": "CA",
+            "alias": "CA"
+          },
+          "type": {
+            "ordinal": false,
+            "subvariables": [
+              "000001",
+              "000002",
+              "000003"
+            ],
+            "class": "categorical",
+            "categories": [
+              {
+                "numeric_value": 0,
+                "selected": false,
+                "id": 2,
+                "missing": false,
+                "name": "A"
+              },
+              {
+                "numeric_value": 1,
+                "selected": false,
+                "id": 1,
+                "missing": false,
+                "name": "B"
+              },
+              {
+                "numeric_value": null,
+                "selected": false,
+                "id": -1,
+                "missing": true,
+                "name": "No Data"
+              }
+            ]
+          }
+        }
+      ],
+      "missing": 1,
+      "measures": {
+        "count": {
+          "data": [
+            1,
+            2,
+            1,
+            2,
+            1,
+            1,
+            2,
+            1,
+            1
+          ],
+          "n_missing": 1,
+          "metadata": {
+            "references": {},
+            "derived": true,
+            "type": {
+              "integer": true,
+              "missing_rules": {},
+              "missing_reasons": {
+                "No Data": -1
+              },
+              "class": "numeric"
+            }
+          }
+        }
+      },
+      "element": "crunch:cube",
+      "counts": [
+        1,
+        2,
+        1,
+        2,
+        1,
+        1,
+        2,
+        1,
+        1
+      ],
+      "n": 4
+    }
+  }
+}

--- a/tests/testthat/test-cube-basic.R
+++ b/tests/testthat/test-cube-basic.R
@@ -1,9 +1,9 @@
 context("Basic cube methods")
 
-v7 <- v7_ifany <- v7_always <- loadCube(test_path("cubes/univariate-categorical.json"))
+v7 <- v7_ifany <- v7_always <- loadCube("cubes/univariate-categorical.json")
 v7_ifany@useNA <- "ifany"
 v7_always@useNA <- "always"
-v4_x_v7 <- v4_x_v7_ifany <- v4_x_v7_always <- loadCube(test_path("cubes/cat-x-cat.json"))
+v4_x_v7 <- v4_x_v7_ifany <- v4_x_v7_always <- loadCube("cubes/cat-x-cat.json")
 v4_x_v7_ifany@useNA <- "ifany"
 v4_x_v7_always@useNA <- "always"
 
@@ -61,7 +61,7 @@ test_that("Cube print method", {
               "  C 5 2 3", sep="\n"))
 })
 
-selected_subvar <- loadCube(test_path("cubes/univariate-categorical-like-selected.json"))
+selected_subvar <- loadCube("cubes/univariate-categorical-like-selected.json")
 
 test_that("Categorical with categories Selected, Not selected", {
     # when detecting if a dimension is selected, we look at the categories. This

--- a/tests/testthat/test-cube-dims.R
+++ b/tests/testthat/test-cube-dims.R
@@ -27,7 +27,7 @@ with_mock_crunch({
             c("What is your favorite pet?",
             "Do you have any of these animals as pets? Please select all that apply."))
         expect_identical(types(variables(d)),
-            c("categorical", "multiple_response"))
+            c("categorical", "subvariable_items"))
     })
     test_that("Getting those additional variable attributes from the cube", {
         expect_identical(names(cube), c("Pet", "All pets owned"))
@@ -36,7 +36,7 @@ with_mock_crunch({
             c("What is your favorite pet?",
             "Do you have any of these animals as pets? Please select all that apply."))
         expect_identical(types(cube),
-            c("categorical", "multiple_response"))
+            c("categorical", "subvariable_items"))
         expect_identical(notes(cube),
             c(NA_character_, NA_character_))
     })

--- a/tests/testthat/test-cube-mr.R
+++ b/tests/testthat/test-cube-mr.R
@@ -10,7 +10,7 @@ alldims <- list(
         "I don't mind paying more for products that are good for the environment")
 )
 
-mr_x_cat_wt <- loadCube(test_path("cubes/selected-crosstab-4.json"))
+mr_x_cat_wt <- loadCube("cubes/selected-crosstab-4.json")
 
 test_that("properties of a cube with for as_selected x cat: it looks 2D", {
     expect_equal(dim(mr_x_cat_wt), c(6L, 3L))

--- a/tests/testthat/test-cube-transforms.R
+++ b/tests/testthat/test-cube-transforms.R
@@ -115,6 +115,46 @@ test_that("categorical arrays with transforms don't error and display cube cells
                   "    CA\nCA    A  B\nmr_1  1  2\nmr_2  2  1\nmr_3  2  1")
 })
 
+test_that("can set transforms on a cube", {
+    transforms(pet_feelings) <- NULL
+    expect_null(transforms(pet_feelings))
+    # transforms(pet_feelings) <- Heading(name = "Fabulous new header", after = 0)
+    # transforms(pet_feelings) <- Subtotal(name = "Fabulous new subtotal",
+    #                                      after = 4,
+    #                                      categories = c("somewhat happy", 
+    #                                                     "neutral",
+    #                                                     "somewhat unhappy"))
+    transforms(pet_feelings) <- list("feelings" = Transforms(
+        insertions = Insertions(
+            Heading(name = "Fabulous new header", after = 0),
+            Subtotal(name = "moderately happy",
+                     after = "somewhat unhappy", 
+                     categories = c("somewhat happy", "neutral",
+                                    "somewhat unhappy"))
+        )))
+
+    all <- array(c(NA, 9, 12, 12, 10, 34, 11,
+                   NA, 5, 12, 7, 10, 29, 12),
+                 dim = c(7, 2),
+                 dimnames = list("feelings" =
+                                     c("Fabulous new header", "extremely happy",
+                                       "somewhat happy", "neutral",
+                                       "somewhat unhappy", "moderately happy",
+                                       "extremely unhappy"),
+                                 "animals" = c("cats", "dogs")))
+    expect_equivalent(applyTransforms(pet_feelings), all)
+    
+    expect_error(
+        transforms(pet_feelings) <- list("not in the var" = Transforms(
+            insertions = Insertions(
+                Heading(name = "Fabulous new header", after = 0),
+                Subtotal(name = "subtotal", after = 2, categories = c(1, 2))
+            ))),
+        paste0("The names of the transforms supplied to not match the ",
+               "dimension names of the cube.")
+    )
+})
+
 test_that("margin.table works with a simple cube and row transforms", {
     feelings_margin <- array(c(14, 24, 38, 19, 20, 23, 43),
                      dimnames = list("feelings" = c("extremely happy", 

--- a/tests/testthat/test-cube-transforms.R
+++ b/tests/testthat/test-cube-transforms.R
@@ -118,12 +118,6 @@ test_that("categorical arrays with transforms don't error and display cube cells
 test_that("can set transforms on a cube", {
     transforms(pet_feelings) <- NULL
     expect_null(transforms(pet_feelings))
-    # transforms(pet_feelings) <- Heading(name = "Fabulous new header", after = 0)
-    # transforms(pet_feelings) <- Subtotal(name = "Fabulous new subtotal",
-    #                                      after = 4,
-    #                                      categories = c("somewhat happy", 
-    #                                                     "neutral",
-    #                                                     "somewhat unhappy"))
     transforms(pet_feelings) <- list("feelings" = Transforms(
         insertions = Insertions(
             Heading(name = "Fabulous new header", after = 0),
@@ -150,8 +144,9 @@ test_that("can set transforms on a cube", {
                 Heading(name = "Fabulous new header", after = 0),
                 Subtotal(name = "subtotal", after = 2, categories = c(1, 2))
             ))),
-        paste0("The names of the transforms supplied to not match the ",
-               "dimension names of the cube.")
+        paste0("The names of the transforms supplied .*not in the var.* to not", 
+               " match the dimension names .*feelings.* and .*animals.* of the", 
+               " cube.")
     )
 })
 

--- a/tests/testthat/test-cube-transforms.R
+++ b/tests/testthat/test-cube-transforms.R
@@ -102,7 +102,7 @@ test_that("applyTransforms with a cube that has transform but no insertions", {
 test_that("categorical arrays with transforms don't error and display cube cells", {
     # TODO: when column display is available, these should be replaced with 
     # proper expectations
-    cat_array_cube <- loadCube(test_path("./cubes/catarray-with-transforms.json"))
+    cat_array_cube <- loadCube("./cubes/catarray-with-transforms.json")
     
     all <- array(c(1, 2, 2, 2, 1, 1),
                  dim = c(3, 2),

--- a/tests/testthat/test-cube-transforms.R
+++ b/tests/testthat/test-cube-transforms.R
@@ -58,7 +58,7 @@ test_that("applyTransforms works with a simple cube and row transforms", {
 
     # can apply to an array of the same shape
     new_array <- cubeToArray(pet_feelings)-1
-    new_all <- all - c(1, 1, 2, 1, 1, 1, 2) # msut subtract two from every subtotal
+    new_all <- all - c(1, 1, 2, 1, 1, 1, 2) # must subtract two from every subtotal
     expect_equivalent(applyTransforms(pet_feelings, array = new_array), new_all)
 })
 
@@ -85,6 +85,35 @@ test_that("applyTransforms can return what is asked for", {
     expect_equivalent(tst, all[c(1, 4, 8),])
 })
 
+test_that("applyTransforms with a cube that has transform but no insertions", {
+    pet_feelings@dims$feelings$references$view$transform$insertions <- list()
+
+    all <- array(c(9, 12, 12, 10, 11,
+                   5, 12, 7, 10, 12),
+                 dim = c(5, 2),
+                 dimnames = list("feelings" =
+                                     c("extremely happy", "somewhat happy",
+                                       "neutral", "somewhat unhappy",
+                                       "extremely unhappy"),
+                                 "animals" = c("cats", "dogs")))
+    expect_equivalent(applyTransforms(pet_feelings), all)
+})
+
+test_that("categorical arrays with transforms don't error and display cube cells", {
+    # TODO: when column display is available, these should be replaced with 
+    # proper expectations
+    cat_array_cube <- loadCube(test_path("./cubes/catarray-with-transforms.json"))
+    
+    all <- array(c(1, 2, 2, 2, 1, 1),
+                 dim = c(3, 2),
+                 dimnames = list("CA" =
+                                     c("mr_1", "mr_2", "mr_3"),
+                                 "CA" = c("A", "B")))
+    
+    expect_equivalent(applyTransforms(cat_array_cube), all)
+    expect_output(cat_array_cube, 
+                  "    CA\nCA    A  B\nmr_1  1  2\nmr_2  2  1\nmr_3  2  1")
+})
 
 test_that("margin.table works with a simple cube and row transforms", {
     feelings_margin <- array(c(14, 24, 38, 19, 20, 23, 43),

--- a/tests/testthat/test-insertions.R
+++ b/tests/testthat/test-insertions.R
@@ -54,6 +54,21 @@ test_that("Insertion and insertions show methods", {
                                         args=c("1 and 2", "9 and 10"))))
 })
 
+test_that("Insertion and insertions show methods with hetrogeneous insertions", {
+    insrts <- Insertions(Subtotal(name = "Cats A+B", after = "B",
+                                  categories = c("A", "B")),
+                         Heading(name = "The end", after = "D"))
+    
+    expect_output(insrts,
+                  get_output(data.frame(
+                     anchor = c("B", "D"),
+                     name = c("Cats A+B", "The end"),
+                     func = c("subtotal", NA),
+                     # NA is a string because we serialPaste them
+                     args = c("A and B", "NA"))),
+                  fixed = TRUE)
+})
+
 test_that("args returns NA when not found", {
     expect_equal(args(Insertion(anchor='foo', name='bar')), NA)
 })

--- a/tests/testthat/test-subtotals-and-headings.R
+++ b/tests/testthat/test-subtotals-and-headings.R
@@ -45,7 +45,7 @@ test_that("Subtotal/Heading getters", {
 with_mock_crunch({
     ds <- loadDataset("test ds")
 
-    test_that("subtotals retrievs the subtotals and headings Insertions", {
+    test_that("subtotals retrieves the subtotals and headings Insertions", {
         expect_equivalent(subtotals(ds$location),
                           Insertions(data=list(
                               Subtotal(name = "London+Scotland", after = 3, 


### PR DESCRIPTION
This PR addresses some rough edges of Subtotals/Heaidngs:
* `Insertions` objects with `Subtotal`s and `Heading`s that have category names (instead of ids) for `after` or `categories` now display nicely, without error, like other abstract categories
* Cubes with categorical arrays or multiple response actively suppress transforms calculations for now (until we have 2d calculation and displaying working)
* cube dimensions that have subreferences are now referred to as `subvariable_items` instead of `multiple_response` since they can be both categorical arrays and multiple response.
* users can now set transforms on CrunchCubes directly.