### PR TITLE
Store spelling language in package DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
     rstudioapi,
     spelling
 VignetteBuilder: knitr
+Language: en-US
 RoxygenNote: 6.0.1
 Roxygen: list(markdown = TRUE)
 Collate: 

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,1 +1,1 @@
-spelling::spell_check_test(vignettes = TRUE, lang = "en_US", error = identical(Sys.getenv("TRAVIS"), "true"))
+spelling::spell_check_test(vignettes = TRUE, error = identical(Sys.getenv("TRAVIS"), "true"))


### PR DESCRIPTION
Thank you for using the spelling package. The new version `spelling 1.1` stores the language in the package `DESCRIPTION` field. 