### PR TITLE
Export test skipping (locally only)

### DIFF
--- a/tests/testthat/test-active-filter.R
+++ b/tests/testthat/test-active-filter.R
@@ -184,10 +184,11 @@ with_test_authentication({
     test_that("as.data.frame when filtered", {
         df2 <- as.data.frame(ds2)
         expect_identical(df2$v3, c(9, 11, 13, 15, 17, 19, 21, 23, 25, 27))
-        expect_equivalent(as.data.frame(ds2[,c("v3", "v4")], force=TRUE),
-            df[df$v4 == "C", c("v3", "v4")])
         df3 <- as.data.frame(ds3)
         expect_equivalent(df3$v3, 12:27)
+        skip_locally("Vagrant host doesn't serve files correctly")
+        expect_equivalent(as.data.frame(ds2[,c("v3", "v4")], force=TRUE),
+                          df[df$v4 == "C", c("v3", "v4")])
     })
 
     test_that("filtered cubing", {

--- a/tests/testthat/test-as-data-frame.R
+++ b/tests/testthat/test-as-data-frame.R
@@ -223,13 +223,15 @@ with_test_authentication({
     })
 
     test_that("as.data.frame(force) with API", {
+        skip_locally("Vagrant host doesn't serve files correctly")
         expect_true(is.data.frame(as.data.frame(as.data.frame(ds))))
         expect_true(is.data.frame(as.data.frame(ds, force=TRUE)))
     })
 
-    mrds <- mrdf.setup(newDataset(mrdf, name = "test-mrdfmr"), selections = "1.0")
-    mrds_df <- as.data.frame(mrds, force = TRUE)
     test_that("Multiple response variables in as.data.frame(force=TRUE)", {
+        skip_locally("Vagrant host doesn't serve files correctly")
+        mrds <- mrdf.setup(newDataset(mrdf, name = "test-mrdfmr"), selections = "1.0")
+        mrds_df <- as.data.frame(mrds, force = TRUE)
         expect_equal(ncol(mrds_df), 4)
         expect_equal(names(mrds_df), c("mr_1", "mr_2", "mr_3", "v4"))
         expect_equal(mrds_df$mr_1, as.vector(mrds$MR$mr_1))

--- a/tests/testthat/test-conditional-transform.R
+++ b/tests/testthat/test-conditional-transform.R
@@ -362,7 +362,6 @@ with_test_authentication({
     })
 
     test_that("conditionalTransform with an exclusion set with a text varaible", {
-        skip("Will fail until bug https://www.pivotaltracker.com/story/show/152700750 is fixed")
         exclusion(ds) <- ds$ndogs > 2
         ds$new10 <- conditionalTransform(ndogs < 1 ~ "lonely",
                                         ndogs == 1 ~ q3,


### PR DESCRIPTION
I've added `skip_locally()` to operations that call `as.data.frame(, force = TRUE)` since those now execute with an export and the local setup doesn't serve exports well. DevOps says they are working on improving that situation, but for now, this will let those tests not fail noisily against a local backend. Because of the way `skip_locally()` works, testing against other backends (alpha/stable/app) will not skip, so we're still covered with jenkins and manual local tests against non-local backends. 

I also removed a skip for an unrelated backend bug that has been fixed.