### PR TITLE
Changed default behaviour for after

### DIFF
--- a/R/subtotals-and-headings.R
+++ b/R/subtotals-and-headings.R
@@ -215,7 +215,8 @@ setMethod("subtotals<-", c("CrunchVariable", "ANY"), function (x, value) {
             } else {
                 var_cats <- names(categories(x))
             }
-            ordered_cats <- a$categories[order(match( a$categories, var_cats))]
+            sub_cats <- a$categories[a$categories %in% var_cats]
+            ordered_cats <- sub_cats[order(match(sub_cats, var_cats))]
             a$after <- rev(ordered_cats)[1]
             return(a)
         } else {

--- a/R/subtotals-and-headings.R
+++ b/R/subtotals-and-headings.R
@@ -42,7 +42,8 @@
 #' the position of the subtotal or heading, either at the top, bottom, or
 #' relative to another category in the cube (default).
 #' @param after character or numeric if `position` is "relative", then the
-#' category name or id to position the subtotal or heading after
+#' category name or id to position the subtotal or heading after. If not supplied
+#' this defaults to the last of the `categories` supplied to `Subtotal`.
 #'
 #' @examples
 #' \dontrun{
@@ -125,18 +126,9 @@ Subtotal <- function (name,
 }
 
 validatePosition <- function (position, after) {
-    if (position == "relative") {
-        # if position is realtive, make sure there is an after
-        if (is.null(after)) {
-            halt("If position is relative, you must supply a category id or ",
-                 "name to the ", dQuote("after"), " argument")
-        }
-    } else {
-        # if position is realtive, make sure there is not an after
-        if (!is.null(after)) {
-            halt("If position is not relative, you cannot supply a category id",
-                 " or name to the ", dQuote("after"), " argument")
-        }
+    if (position != "relative" && !is.null(after)) {
+        halt("If position is not relative, you cannot supply a category id",
+            " or name to the ", dQuote("after"), " argument")
     }
 }
 
@@ -214,6 +206,22 @@ setMethod("subtotals<-", c("CrunchVariable", "ANY"), function (x, value) {
         }, value)))) {
         halt("value must be a list of Subtotals, Headings, or both.")
     }
+    # If position is relative we default to setting after to be the last category
+    # in the Subtotal category.
+    value <- lapply(value, function(a){
+        if (is.null(a$after) && a$position == "relative") {
+            if (is.numeric(a$categories)) {
+                var_cats <- ids(categories(x))
+            } else {
+                var_cats <- names(categories(x))
+            }
+            ordered_cats <- a$categories[order(match( a$categories, var_cats))]
+            a$after <- rev(ordered_cats)[1]
+            return(a)
+        } else {
+            return(a)
+        }
+    })
     inserts = Insertions(data = lapply(value,
                                        makeInsertion,
                                        var_categories = categories(x)))

--- a/man/SubtotalsHeadings.Rd
+++ b/man/SubtotalsHeadings.Rd
@@ -58,7 +58,8 @@ the position of the subtotal or heading, either at the top, bottom, or
 relative to another category in the cube (default).}
 
 \item{after}{character or numeric if \code{position} is "relative", then the
-category name or id to position the subtotal or heading after}
+category name or id to position the subtotal or heading after. If not supplied
+this defaults to the last of the \code{categories} supplied to \code{Subtotal}.}
 
 \item{x}{either a variable or CrunchCube object to add or get subtotal
 transforms for}

--- a/tests/testthat/test-subtotals-and-headings.R
+++ b/tests/testthat/test-subtotals-and-headings.R
@@ -22,9 +22,6 @@ test_that("Subtotal validates", {
                  "argument \"name\" is missing, with no default")
     expect_error(Subtotal(name = "Total Approval", after = 2),
                  "argument \"categories\" is missing, with no default")
-    expect_error(Subtotal(name = "Total Approval", categories = c(1, 2)),
-                 paste0("If position is relative, you must supply a category ",
-                        "id or name to the .*after.* argument"))
 })
 
 test_that("Subtotal validates with fixed positions", {
@@ -39,9 +36,6 @@ test_that("Subtotal validates with fixed positions", {
 test_that("Heading validates", {
     expect_error(Heading(after = 2),
                  "argument \"name\" is missing, with no default")
-    expect_error(Heading(name = "All the approves"),
-                 paste0("If position is relative, you must supply a category ",
-                        "id or name to the .*after.* argument"))
     expect_error(Heading(name = "All the approves", after = 2, categories = c(1, 2)),
                  "unused argument (categories = c(1, 2))", fixed = TRUE)
 })
@@ -128,6 +122,17 @@ with_mock_crunch({
         '{"anchor":2,"name":"Not men","function":"subtotal","args":[1,-1]},',
         '{"anchor":4,"name":"Women","function":"subtotal","args":[2]},',
         '{"anchor":"top","name":"A subtitle"}]}}}')
+    })
+
+    test_that("When after is not supplied, it defauls to follow the last category", {
+        expect_PATCH(subtotals(ds$gender) <- list(
+            Subtotal(name = "Not men", categories = c(-1, 1)), # categories supplied in reverse order
+            Subtotal(name = "Women", categories = "Female")
+        ),
+            'https://app.crunch.io/api/datasets/1/variables/gender/',
+            '{"view":{"transform":{"insertions":[',
+            '{"anchor":-1,"name":"Not men","function":"subtotal","args":[-1,1]},',
+            '{"anchor":2,"name":"Women","function":"subtotal","args":[2]}]}}}')
     })
 
     test_that("subtotals and headers to a variable that has some, appends", {

--- a/tests/testthat/test-subtotals-and-headings.R
+++ b/tests/testthat/test-subtotals-and-headings.R
@@ -133,6 +133,16 @@ with_mock_crunch({
             '{"view":{"transform":{"insertions":[',
             '{"anchor":-1,"name":"Not men","function":"subtotal","args":[-1,1]},',
             '{"anchor":2,"name":"Women","function":"subtotal","args":[2]}]}}}')
+
+        # one supplied category (23) isn't a real category, after should still be -1
+        expect_PATCH(subtotals(ds$gender) <- list(
+            Subtotal(name = "Not men", categories = c(-1, 1, 23)), # categories supplied in reverse order
+            Subtotal(name = "Women", categories = "Female")
+        ),
+            'https://app.crunch.io/api/datasets/1/variables/gender/',
+            '{"view":{"transform":{"insertions":[',
+            '{"anchor":-1,"name":"Not men","function":"subtotal","args":[-1,1,23]},',
+            '{"anchor":2,"name":"Women","function":"subtotal","args":[2]}]}}}')
     })
 
     test_that("subtotals and headers to a variable that has some, appends", {


### PR DESCRIPTION
Small change to set default `after` value for subtotal if the position is relative and after is not supplied. If `after` is not supplied it defaults to the category specified in the `categories` argument to `Subtotal`. Last in this case refers to the order of the variable's categories, not the order that those categories are supplied to `Subtotal`.