### PR TITLE
Test cleanup: expect_prints

### DIFF
--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -1,13 +1,9 @@
-expect_output <- function (object, ...) {
-    testthat::expect_output(print(object), ...)
-}
-
-expect_fixed_output <- function (object, ...) {
-    expect_output(object, ..., fixed=TRUE)
+expect_prints <- function (object, ..., fixed=TRUE) {
+    expect_output(print(object), ..., fixed=fixed)
 }
 
 get_output <- function (x) {
-    ## For comparing print output in expect_output
+    ## For comparing print output in expect_prints
     paste(capture.output(print(x)), collapse="\n")
 }
 

--- a/tests/testthat/print-folders.R
+++ b/tests/testthat/print-folders.R
@@ -1,5 +1,5 @@
 ## These are moved from test-variable-folder.R thanks to R's archaic restriction on UTF-8
-testthat::expect_output(print(folders(ds), depth=2),
+expect_output(print(folders(ds), depth=2),
 "/
 ├── Group 1/
 │   ├── Birth Year
@@ -13,7 +13,7 @@ testthat::expect_output(print(folders(ds), depth=2),
     └── Cat Array", fixed=TRUE
 )
 
-testthat::expect_output(print(folders(ds), depth=1),
+expect_output(print(folders(ds), depth=1),
 "/
 ├── Group 1/
 │   ├── Birth Year
@@ -24,13 +24,13 @@ testthat::expect_output(print(folders(ds), depth=1),
     └── Cat Array", fixed=TRUE
 )
 
-testthat::expect_output(print(folders(ds), pretty=TRUE),
+expect_output(print(folders(ds), pretty=TRUE),
 "/
 ├── Group 1/
 └── Group 2/", fixed=TRUE
 )
 
-testthat::expect_output(print(folders(ds)[["Group 1/Nested"]], pretty=TRUE),
+expect_output(print(folders(ds)[["Group 1/Nested"]], pretty=TRUE),
 "/Group 1/Nested/
 ├── Gender
 ├── Categorical Location
@@ -38,7 +38,7 @@ testthat::expect_output(print(folders(ds)[["Group 1/Nested"]], pretty=TRUE),
 )
 
 with(temp.option(crunch.delimiter="|"), {
-    testthat::expect_output(print(folders(ds), depth=2),
+    expect_output(print(folders(ds), depth=2),
 "|
 ├── Group 1|
 │   ├── Birth Year

--- a/tests/testthat/test-active-filter.R
+++ b/tests/testthat/test-active-filter.R
@@ -164,7 +164,7 @@ with_test_authentication({
     })
 
     test_that("activeFilter appears in print method for dataset", {
-        expect_output(ds3, "Filtered by v3 > 11")
+        expect_prints(ds3, "Filtered by v3 > 11")
         expect_false(any(grepl("Filtered by", get_output(ds))))
     })
 
@@ -178,7 +178,7 @@ with_test_authentication({
     })
 
     test_that("activeFilter appears in print method for variables", {
-        expect_output(ds3$v3, "Filtered by v3 > 11")
+        expect_prints(ds3$v3, "Filtered by v3 > 11")
     })
 
     test_that("as.data.frame when filtered", {

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -10,7 +10,7 @@ test_that("Deprecated endpoints tell user to upgrade", {
 with_mock_crunch({
     test_that("crunch.debug does not print if disabled", {
         expect_POST(
-            expect_output(crPOST("https://app.crunch.io/api/", body='{"value":1}'),
+            expect_prints(crPOST("https://app.crunch.io/api/", body='{"value":1}'),
                 NA),
             "https://app.crunch.io/api/",
             '{"value":1}')
@@ -18,13 +18,13 @@ with_mock_crunch({
     test_that("crunch.debug logging if enabled", {
         with(temp.option(crunch.debug=TRUE), {
             expect_POST(
-                expect_output(crPOST("https://app.crunch.io/api/", body='{"value":1}'),
+                expect_prints(crPOST("https://app.crunch.io/api/", body='{"value":1}'),
                     '\n {"value":1} \n',
                     fixed=TRUE),
                 "https://app.crunch.io/api/",
                 '{"value":1}')
             ## Use testthat:: so that it doesn't print ds. Check for log printing
-            testthat::expect_output(ds <- loadDataset("test ds"),
+            expect_output(ds <- loadDataset("test ds"),
                 NA)
         })
     })

--- a/tests/testthat/test-append-arrays.R
+++ b/tests/testthat/test-append-arrays.R
@@ -21,7 +21,7 @@ with_test_authentication({
             expect_length(batches(part2), 2)
         })
         test_that("compareDatasets says they're all good", {
-            expect_output(summary(compareDatasets(part1, part2)),
+            expect_prints(summary(compareDatasets(part1, part2)),
                 "All good :)")
         })
         test_that("they append successfully", {
@@ -45,7 +45,7 @@ with_test_authentication({
                             mr_2=c(rep(NA, 995), 0, 1, 1, 1, 0),
                             v4=as.factor(LETTERS[2:3]))))
         test_that("compareDatasets identifies the category id mismatch", {
-            expect_output(summary(compareDatasets(part1, part2)),
+            expect_prints(summary(compareDatasets(part1, part2)),
                 paste(
                     "Mismatched ids: 4 ",
                     " id.A name id.B",
@@ -80,7 +80,7 @@ with_test_authentication({
         ## Aliases are c("mr_1", "mr_2", "alt")
 
         test_that("compareDatasets sees the mismatch", {
-            expect_output(summary(compareDatasets(part1, part2)),
+            expect_prints(summary(compareDatasets(part1, part2)),
                 paste(
                     "Mismatched names: 2 ",
                     " name.A alias name.B",

--- a/tests/testthat/test-append-conflicts.R
+++ b/tests/testthat/test-append-conflicts.R
@@ -12,16 +12,16 @@ with_test_authentication({
             expect_true("CA" %in% names(part2))
             expect_true(is.CA(part1$CA))
             expect_true(is.Numeric(part2$CA))
-            expect_output(batches(part1),
+            expect_prints(batches(part1),
                 get_output(data.frame(id=c(0, 1),
                 status=c("imported", "imported"))))
         })
         test_that("compareDatasets catches that", {
             comp <- compareDatasets(part1, part2)
-            expect_output(summary(comp), "Type mismatch: 1")
+            expect_prints(summary(comp), "Type mismatch: 1")
         })
         test_that("If the append fails and reports conflict, and the batch is backed out", {
-            expect_output(batches(part1),
+            expect_prints(batches(part1),
                 get_output(data.frame(id=c(0, 1),
                 status=c("imported", "imported"))))
 
@@ -31,7 +31,7 @@ with_test_authentication({
                 NA) ## No Result URL printed because autorollback=TRUE
 
             part1 <- refresh(part1)
-            expect_output(batches(part1),
+            expect_prints(batches(part1),
                 get_output(data.frame(id=c(0, 1),
                 status=c("imported", "imported"))))
         })
@@ -44,7 +44,7 @@ with_test_authentication({
         part2 <- newDataset(d2)
         test_that("compareDatasets catches that", {
             comp <- compareDatasets(part1, part2)
-            expect_output(summary(comp), "Type mismatch: 1")
+            expect_prints(summary(comp), "Type mismatch: 1")
         })
         test_that("Append detects text/numeric type mismatch", {
             expect_error(appendDataset(part1, part2),

--- a/tests/testthat/test-append-debug.R
+++ b/tests/testthat/test-append-debug.R
@@ -40,7 +40,7 @@ with_test_authentication({
         })
         test_that("compareDatasets catches that parent mismatch", {
             comp <- compareDatasets(part1, part2)
-            expect_output(summary(comp),
+            expect_prints(summary(comp),
                 "Contains subvariables found in other arrays after matching: CA2")
         })
         test_that("The append fails", {

--- a/tests/testthat/test-batches.R
+++ b/tests/testthat/test-batches.R
@@ -28,7 +28,7 @@ with_mock_crunch({
             ))
     })
     test_that("show method for batch catalog", {
-        expect_output(batches(ds),
+        expect_prints(batches(ds),
             get_output(data.frame(id=c(0, 2, 3),
             status=c("imported", "imported", "conflict"))))
     })

--- a/tests/testthat/test-categories.R
+++ b/tests/testthat/test-categories.R
@@ -13,9 +13,9 @@ with_mock_crunch({
     })
 
     test_that("Categories print method", {
-        expect_output(cats[[1]],
+        expect_prints(cats[[1]],
                       get_output(data.frame(id=1, name="Male", value=1, missing=FALSE)))
-        expect_output(cats,
+        expect_prints(cats,
                       get_output(data.frame(id=c(1, 2, -1), name=c("Male", "Female", "No Data"), value=c(1, 2, NA), missing=c(FALSE, FALSE, TRUE))))
     })
 

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -31,7 +31,7 @@ test_that("summarizeCompareCategories", {
 })
 
 test_that("print compareCategory summary", {
-    expect_output(summary(compareCategories(cat1, cat2)),
+    expect_prints(summary(compareCategories(cat1, cat2)),
         paste(
             "Total categories: 4 ",
             "",
@@ -45,7 +45,7 @@ test_that("print compareCategory summary", {
 
 test_that("print compareCategory summary when categories are equivalent", {
     summary(compareCategories(cat1, cat1))
-    expect_output(summary(compareCategories(cat1, cat1)),
+    expect_prints(summary(compareCategories(cat1, cat1)),
         paste(
             "Total categories: 3 ",
             "All good :)",
@@ -64,7 +64,7 @@ with_mock_crunch({
     })
 
     test_that("print compareVariables", {
-        expect_output(summary(compareVariables(allVariables(ds1), allVariables(ds2))),
+        expect_prints(summary(compareVariables(allVariables(ds1), allVariables(ds2))),
             paste(
                 "Total variables: 9 ",
                 "",
@@ -81,7 +81,7 @@ with_mock_crunch({
                 ))
     })
     test_that("compareVariables when everything is ok", {
-        expect_output(summary(compareVariables(allVariables(ds1), allVariables(ds1))),
+        expect_prints(summary(compareVariables(allVariables(ds1), allVariables(ds1))),
             paste(
                 "Total variables: 7 ",
                 "No type or name mismatches.",
@@ -95,7 +95,7 @@ with_mock_crunch({
 
     test_that("compareDatasets", {
         compareDatasets(ds1, ds2)
-        expect_output(summary(compareDatasets(ds1, ds2)),
+        expect_prints(summary(compareDatasets(ds1, ds2)),
             paste(
                 "Total variables: 9 ",
                 "",
@@ -148,7 +148,7 @@ with_mock_crunch({
     })
 
     test_that("compareDatasets when everything is ok", {
-        expect_output(summary(compareDatasets(ds2, ds2)),
+        expect_prints(summary(compareDatasets(ds2, ds2)),
             paste(
                 "Total variables: 5 ",
                 "All good :)",

--- a/tests/testthat/test-crunchbox.R
+++ b/tests/testthat/test-crunchbox.R
@@ -15,9 +15,9 @@ test_that("Embed URL", {
 })
 
 test_that("Iframe code (prints and returns invisibly)", {
-    ## Use the testthat version of expect_output because the crunch version
+    ## Use the testthat version of expect_prints because the crunch version
     ## calls print explicitly
-    testthat::expect_output(
+    expect_output(
         expect_identical(embedCrunchBox("http://cf.example/d/stuff/1a1577c91fbb2c1cbd3800e181188508/dataset.json"),
             '<iframe src="//s.crunch.io/widget/index.html#/ds/1a1577c91fbb2c1cbd3800e181188508/" width="600" height="480" style="border: 1px solid #d3d3d3;"></iframe>'),
         '<iframe src="//s.crunch.io/widget/index.html#/ds/1a1577c91fbb2c1cbd3800e181188508/" width="600" height="480" style="border: 1px solid #d3d3d3;"></iframe>',
@@ -38,7 +38,7 @@ iframe_with_title <- '<figure style="text-align: left;" class="content-list-comp
 
 
 test_that("Iframe code with logo", {
-    testthat::expect_output(
+    expect_output(
         expect_identical(embedCrunchBox("http://cf.example/d/stuff/1a1577c91fbb2c1cbd3800e181188508/dataset.json", logo="//s.crunch.io/public/branding/example.gif"),
             iframe_with_logo),
         iframe_with_logo,
@@ -46,7 +46,7 @@ test_that("Iframe code with logo", {
 })
 
 test_that("Iframe code with title", {
-    testthat::expect_output(
+    expect_output(
         expect_identical(embedCrunchBox("http://cf.example/d/stuff/1a1577c91fbb2c1cbd3800e181188508/dataset.json", title="Example title here"),
             iframe_with_title),
         iframe_with_title,
@@ -74,7 +74,7 @@ with_mock_crunch({
     ds3 <- loadDataset("ECON.sav")
 
     test_that("preCrunchBoxCheck does not error", {
-        expect_output(preCrunchBoxCheck(ds),
+        expect_prints(preCrunchBoxCheck(ds),
             "We recommend using only categorical and multiple_response variables. These 4 variables have an unsupported type")
     })
 
@@ -218,7 +218,7 @@ with_test_authentication({
     names(categories(ds$cat))[2] <- "Extra long category name because we check those too"
 
     test_that("check box catches the various cases", {
-        expect_output(preCrunchBoxCheck(ds),
+        expect_prints(preCrunchBoxCheck(ds),
             "Shorter variable names will display in the menus better. This variable has a name longer than 40 characters")
     })
 

--- a/tests/testthat/test-crunchbox.R
+++ b/tests/testthat/test-crunchbox.R
@@ -15,8 +15,6 @@ test_that("Embed URL", {
 })
 
 test_that("Iframe code (prints and returns invisibly)", {
-    ## Use the testthat version of expect_prints because the crunch version
-    ## calls print explicitly
     expect_output(
         expect_identical(embedCrunchBox("http://cf.example/d/stuff/1a1577c91fbb2c1cbd3800e181188508/dataset.json"),
             '<iframe src="//s.crunch.io/widget/index.html#/ds/1a1577c91fbb2c1cbd3800e181188508/" width="600" height="480" style="border: 1px solid #d3d3d3;"></iframe>'),

--- a/tests/testthat/test-cube-basic.R
+++ b/tests/testthat/test-cube-basic.R
@@ -54,7 +54,7 @@ test_that("useNA on bivariate cube", {
 })
 
 test_that("Cube print method", {
-    expect_output(v4_x_v7_ifany,
+    expect_prints(v4_x_v7_ifany,
         paste("   v7",
               "v4  C D E",
               "  B 5 3 2",
@@ -67,7 +67,7 @@ test_that("Categorical with categories Selected, Not selected", {
     # when detecting if a dimension is selected, we look at the categories. This
     # breaks if one tries to display a categorical that just so happens to have
     # Selected and Not selected as categories
-    expect_output(selected_subvar,
+    expect_prints(selected_subvar,
                   paste("selected_like",
                         "    Selected Not selected ",
                         "          10            5 ",

--- a/tests/testthat/test-cube-transforms.R
+++ b/tests/testthat/test-cube-transforms.R
@@ -5,7 +5,7 @@ unicat_trans_cube <- loadCube("cubes/univariate-categorical-with-trans.json")
 test_that("Can show a simple cube with transform", {
     loc_array <- array(c(10, 5, 15, NA),
                      dimnames = list("v7" = c("C", "E", "C, E", "D, E")))
-    expect_output(expect_equivalent(showTransforms(unicat_trans_cube), loc_array))
+    expect_prints(expect_equivalent(showTransforms(unicat_trans_cube), loc_array))
 })
 
 test_that("can retrieve transformations from a cube", {
@@ -35,7 +35,7 @@ test_that("Can show a complex cube with transform", {
                                               "D", "E", "F", "G", "Middle 5",
                                               "H", "I", "J", "Bottom 8",
                                               "Middle 3 (missing anchor)", "J and can't see")))
-    expect_output(expect_equivalent(showTransforms(complex_trans_cube), loc_array))
+    expect_prints(expect_equivalent(showTransforms(complex_trans_cube), loc_array))
 })
 
 pet_feelings <- pet_feelings_headers <- loadCube("./cubes/feelings-pets.json")
@@ -111,7 +111,7 @@ test_that("categorical arrays with transforms don't error and display cube cells
                                  "CA" = c("A", "B")))
 
     expect_equivalent(applyTransforms(cat_array_cube), all)
-    expect_output(cat_array_cube,
+    expect_prints(cat_array_cube,
                   "    CA\nCA    A  B\nmr_1  1  2\nmr_2  2  1\nmr_3  2  1")
 })
 
@@ -253,7 +253,7 @@ with_test_authentication({
                              dim = 4,
                              dimnames = list(pets = c("Birds", "Catds",
                                                       "Dogs", "Lizards")))
-        expect_output(expect_equivalent(showTransforms(ds$pets), cat_summary))
+        expect_prints(expect_equivalent(showTransforms(ds$pets), cat_summary))
     })
 
     # add transforms
@@ -278,7 +278,7 @@ with_test_authentication({
                                  "Dogs+Cats", "Lizards", "Birds+Lizards",
                                  "Toward the end", "Cats+Birds (missing anch.)",
                                  "Rocks+Birds (incl. missing)")))
-        expect_output(trans_pets <- showTransforms(ds$pets),
+        expect_prints(trans_pets <- showTransforms(ds$pets),
                       paste(
             "                             ",
             "                           ",
@@ -308,7 +308,7 @@ with_test_authentication({
                                     "Rocks+Birds (incl. missing)")))
 
         pets_cube <- crtabs(~pets, ds)
-        expect_output(trans_cube <- showTransforms(pets_cube),
+        expect_prints(trans_cube <- showTransforms(pets_cube),
                       paste(
               "                             ",
               "                           ",

--- a/tests/testthat/test-dataset-entity.R
+++ b/tests/testthat/test-dataset-entity.R
@@ -292,7 +292,7 @@ with_mock_crunch({
         expect_null(activeFilter(ds[rep(TRUE, nrow(ds)),]))
         expect_error(ds[c(TRUE, FALSE),],
             "Logical filter vector is length 2, but dataset has 25 rows")
-        expect_fixed_output(toJSON(activeFilter(ds[c(rep(FALSE, 4), TRUE,
+        expect_prints(toJSON(activeFilter(ds[c(rep(FALSE, 4), TRUE,
             rep(FALSE, 20)),])),
             paste0('{"function":"==","args":[{"function":"row",',
             '"args":[]},{"value":4}]}'))

--- a/tests/testthat/test-derive.R
+++ b/tests/testthat/test-derive.R
@@ -12,7 +12,7 @@ with_mock_crunch({
     test_that("derivation pulls the derivation", {
         expect_is(derivation(birthyrPlus), "CrunchExpr")
         expect_true(is.derived(birthyrPlus))
-        expect_fixed_output(derivation(birthyrPlus), "Crunch expression: birthyr + 100")
+        expect_prints(derivation(birthyrPlus), "Crunch expression: birthyr + 100")
     })
 
     test_that("derivation returns NULL if the variable is not derived", {
@@ -79,7 +79,7 @@ with_test_authentication({
 
     test_that("derivation pulls the derivation", {
         expect_is(derivation(ds$v3a), "CrunchExpr")
-        expect_fixed_output(derivation(ds$v3a), "Crunch expression: v3 + 5")
+        expect_prints(derivation(ds$v3a), "Crunch expression: v3 + 5")
     })
 
     test_that("derivation returns NULL if the variable is not derived", {
@@ -89,10 +89,10 @@ with_test_authentication({
     test_that("derivation()<- can change a derived variable", {
         ds$v3d <- ds$v3 + 10
         expect_true(is.derived(ds$v3d))
-        expect_fixed_output(derivation(ds$v3d), "Crunch expression: v3 + 10")
+        expect_prints(derivation(ds$v3d), "Crunch expression: v3 + 10")
         derivation(ds$v3d) <- ds$v3 + 1
         expect_true(is.derived(ds$v3d))
-        expect_fixed_output(derivation(ds$v3d), "Crunch expression: v3 + 1")
+        expect_prints(derivation(ds$v3d), "Crunch expression: v3 + 1")
     })
 
     ## Now update v3's values and confirm that v3a is still linked

--- a/tests/testthat/test-exclusion-filter.R
+++ b/tests/testthat/test-exclusion-filter.R
@@ -41,7 +41,7 @@ with_test_authentication({
             ## Test that the filter is set correctly. Objects not identical
             ## because JSON objects are unordered.
             expect_json_equivalent(zcl(exclusion(ds)), zcl(ds$v4 == "C"))
-            expect_output(exclusion(ds),
+            expect_prints(exclusion(ds),
                 'Crunch logical expression: v4 == "C"')
 
             expect_identical(nrow(ds), 10L)

--- a/tests/testthat/test-expressions.R
+++ b/tests/testthat/test-expressions.R
@@ -1,14 +1,14 @@
 context("Expressions")
 
 test_that(".dispatchFilter uses right numeric function", {
-    ## Use expect_output because toJSON returns class "json" but prints correctly
-    expect_fixed_output(toJSON(.dispatchFilter(5)),
+    ## Use expect_prints because toJSON returns class "json" but prints correctly
+    expect_prints(toJSON(.dispatchFilter(5)),
         paste0('{"function":"==","args":[{"function":"row",',
         '"args":[]},{"value":4}]}'))
-    expect_fixed_output(toJSON(.dispatchFilter(c(5, 7))),
+    expect_prints(toJSON(.dispatchFilter(c(5, 7))),
         paste0('{"function":"in","args":[{"function":"row",',
         '"args":[]},{"column":[4,6]}]}'))
-    expect_fixed_output(toJSON(.dispatchFilter(5:7)),
+    expect_prints(toJSON(.dispatchFilter(5:7)),
         paste0('{"function":"between","args":[{"function":"row",',
         '"args":[]},{"value":4},',
         '{"value":7}]}'))
@@ -33,22 +33,22 @@ with_mock_crunch({
             )
         )
         expect_identical(zcl(e1), zexp)
-        expect_fixed_output(e1, "Crunch expression: birthyr + 5")
+        expect_prints(e1, "Crunch expression: birthyr + 5")
         e2 <- 5 + ds$birthyr
         expect_is(e2, "CrunchExpr")
-        expect_fixed_output(e2, "Crunch expression: 5 + birthyr")
+        expect_prints(e2, "Crunch expression: 5 + birthyr")
     })
 
     test_that("Integer printing removes L", {
         e1 <- ds$birthyr + 1L
         expect_is(e1, "CrunchExpr")
-        expect_fixed_output(e1, "Crunch expression: birthyr + 1")
+        expect_prints(e1, "Crunch expression: birthyr + 1")
     })
 
     test_that("Logic generates expressions", {
         e1 <- ds$birthyr < 0
         expect_is(e1, "CrunchLogicalExpr")
-        expect_fixed_output(e1, "Crunch logical expression: birthyr < 0")
+        expect_prints(e1, "Crunch logical expression: birthyr < 0")
     })
 
     test_that("R logical & CrunchLogicalExpr", {
@@ -63,66 +63,66 @@ with_mock_crunch({
     })
 
     test_that("Datetime operations: logical", {
-        expect_fixed_output(ds$starttime == "2015-01-01",
+        expect_prints(ds$starttime == "2015-01-01",
             'Crunch logical expression: starttime == "2015-01-01"')
-        expect_fixed_output(ds$starttime > "2015-01-01",
+        expect_prints(ds$starttime > "2015-01-01",
             'Crunch logical expression: starttime > "2015-01-01"')
-        expect_fixed_output(ds$starttime == as.Date("2015-01-01"),
+        expect_prints(ds$starttime == as.Date("2015-01-01"),
             'Crunch logical expression: starttime == "2015-01-01"')
-        expect_fixed_output(ds$starttime > as.Date("2015-01-01"),
+        expect_prints(ds$starttime > as.Date("2015-01-01"),
             'Crunch logical expression: starttime > "2015-01-01"')
     })
 
     test_that("Logical expr with categoricals", {
         expect_is(ds$gender == "Male", "CrunchLogicalExpr")
-        expect_fixed_output(ds$gender == "Male",
+        expect_prints(ds$gender == "Male",
             'Crunch logical expression: gender == "Male"')
-        expect_fixed_output(ds$gender == as.factor("Male"),
+        expect_prints(ds$gender == as.factor("Male"),
             'Crunch logical expression: gender == "Male"')
-        expect_fixed_output(ds$gender %in% "Male",
+        expect_prints(ds$gender %in% "Male",
             'Crunch logical expression: gender == "Male"')
-        expect_fixed_output(ds$gender %in% as.factor("Male"),
+        expect_prints(ds$gender %in% as.factor("Male"),
             'Crunch logical expression: gender == "Male"')
-        expect_fixed_output(ds$gender %in% c("Male", "Female"),
+        expect_prints(ds$gender %in% c("Male", "Female"),
             'Crunch logical expression: gender %in% c("Male", "Female")')
-        expect_fixed_output(ds$gender %in% as.factor(c("Male", "Female")),
+        expect_prints(ds$gender %in% as.factor(c("Male", "Female")),
             'Crunch logical expression: gender %in% c("Male", "Female")')
-        expect_fixed_output(ds$gender != "Female",
+        expect_prints(ds$gender != "Female",
             'Crunch logical expression: gender != "Female"')
-        expect_fixed_output(ds$gender != as.factor("Female"),
+        expect_prints(ds$gender != as.factor("Female"),
             'Crunch logical expression: gender != "Female"')
     })
     test_that("Referencing category names that don't exist warns and drops", {
         expect_warning(
-            expect_fixed_output(ds$gender == "other",
+            expect_prints(ds$gender == "other",
                 'Crunch logical expression: gender %in% character(0)'),
             paste("Category not found:", dQuote("other")))
         expect_warning(
-            expect_fixed_output(ds$gender %in% c("other", "Male", "another"),
+            expect_prints(ds$gender %in% c("other", "Male", "another"),
                 'Crunch logical expression: gender == "Male"'),
             paste("Categories not found:", dQuote("other"), "and",
                 dQuote("another")))
         expect_warning(
-            expect_fixed_output(ds$gender != "other",
+            expect_prints(ds$gender != "other",
                 'Crunch logical expression: !gender %in% character(0)'),
             paste("Category not found:", dQuote("other")))
     })
 
     test_that("Show method for logical expressions", {
-        expect_fixed_output(ds$gender %in% c("Male", "Female"),
+        expect_prints(ds$gender %in% c("Male", "Female"),
             'Crunch logical expression: gender %in% c("Male", "Female"')
-        expect_fixed_output(ds$gender %in% 1:2,
+        expect_prints(ds$gender %in% 1:2,
             'Crunch logical expression: gender %in% c("Male", "Female"')
-        expect_fixed_output(ds$birthyr == 1945 | ds$birthyr < 1941,
+        expect_prints(ds$birthyr == 1945 | ds$birthyr < 1941,
             'birthyr == 1945 | birthyr < 1941')
-        expect_fixed_output(ds$gender %in% "Male" & !is.na(ds$birthyr),
+        expect_prints(ds$gender %in% "Male" & !is.na(ds$birthyr),
             'gender == "Male" & !is.na(birthyr)')
-        expect_fixed_output(!(ds$gender == "Male"),
+        expect_prints(!(ds$gender == "Male"),
             'Crunch logical expression: !gender == "Male"')
             ## TODO: better parentheses for ^^
-        expect_fixed_output(duplicated(ds$gender),
+        expect_prints(duplicated(ds$gender),
             'Crunch logical expression: duplicated(gender)')
-        expect_fixed_output(duplicated(ds$gender == "Male"),
+        expect_prints(duplicated(ds$gender == "Male"),
             'Crunch logical expression: duplicated(gender == "Male")')
     })
 
@@ -130,11 +130,11 @@ with_mock_crunch({
         age <- 2016 - ds$birthyr
         ## Note: no check for correct number of rows
         expect_is(age[c(TRUE, FALSE, TRUE)], "CrunchExpr")
-        expect_fixed_output(toJSON(activeFilter(age[c(TRUE, FALSE, TRUE)])),
+        expect_prints(toJSON(activeFilter(age[c(TRUE, FALSE, TRUE)])),
             paste0('{"function":"in","args":[{"function":"row",',
             '"args":[]},{"column":[0,2]}]}'))
         expect_is(age[c(1, 3)], "CrunchExpr")
-        expect_fixed_output(toJSON(activeFilter(age[c(1, 3)])),
+        expect_prints(toJSON(activeFilter(age[c(1, 3)])),
             paste0('{"function":"in","args":[{"function":"row",',
             '"args":[]},{"column":[0,2]}]}'))
     })
@@ -208,11 +208,11 @@ with_test_authentication({
     test_that("expressions on expresssions evaluate", {
         e3 <- ds$v3 + ds$v3 + 10
         expect_is(e3, "CrunchExpr")
-        expect_fixed_output(e3, "Crunch expression: v3 + v3 + 10")
+        expect_prints(e3, "Crunch expression: v3 + v3 + 10")
         expect_identical(as.vector(e3), 2*df$v3 + 10)
         e4 <- ds$v3 + ds$v3 * 2
         expect_is(e4, "CrunchExpr")
-        expect_fixed_output(e4, "Crunch expression: v3 + v3 * 2")
+        expect_prints(e4, "Crunch expression: v3 + v3 * 2")
         expect_identical(as.vector(e4), 3*df$v3)
     })
 

--- a/tests/testthat/test-filters.R
+++ b/tests/testthat/test-filters.R
@@ -18,7 +18,7 @@ with_mock_crunch({
                 is_public=c(FALSE, TRUE),
                 stringsAsFactors=FALSE
             ))
-        expect_output(filters(ds),
+        expect_prints(filters(ds),
             get_output(data.frame(
                     name=c("Occasional Political Interest", "Public filter"),
                     id=c("filter1", "filter2"),
@@ -29,7 +29,7 @@ with_mock_crunch({
     test_that("Empty filter catalog", {
         expect_is(filters(ds3), "FilterCatalog")
         expect_length(filters(ds3), 0)
-        expect_output(filters(ds3), get_output(data.frame()))
+        expect_prints(filters(ds3), get_output(data.frame()))
     })
 
     test_that("Filter catalog methods", {
@@ -118,7 +118,7 @@ with_mock_crunch({
     test_that("Print method for filter entity (debug)", {
         f <- CrunchFilter(crGET("a-filter/"))
         expect_is(f, "CrunchFilter")
-        expect_fixed_output(f,
+        expect_prints(f,
             'starttime %in% c("2016-04-06", "2016-04-15", "2016-04-25", "2016-05-06", "2016-05-13", "2016-05-27", "2016-06-06", "2016-06-14", "2016-06-29") & gender %in% "Male"')
     })
 })
@@ -137,13 +137,13 @@ with_test_authentication({
         expect_identical(name(filters(ds)[[1]]), "Test filter")
     })
     test_that("Show methods for filter and filter catalog", {
-        expect_output(filters(ds),
+        expect_prints(filters(ds),
             get_output(data.frame(
                     name="Test filter",
                     id=filters(ds)[["Test filter"]]@body$id,
                     is_public=FALSE
                 )), fixed=TRUE)
-        expect_output(filters(ds)[["Test filter"]],
+        expect_prints(filters(ds)[["Test filter"]],
             paste0('Crunch filter ', dQuote("Test filter"),
                 '\nExpression: v4 == "B"'))
     })

--- a/tests/testthat/test-fork.R
+++ b/tests/testthat/test-fork.R
@@ -59,8 +59,8 @@ with_test_authentication({
     })
 
     test_that("Forking preserves exclusion filters", {
-        expect_output(exclusion(f1), "v3 < 11")
-        expect_output(exclusion(f2), "v3 < 11")
+        expect_prints(exclusion(f1), "v3 < 11")
+        expect_prints(exclusion(f2), "v3 < 11")
         expect_identical(nrow(f2), 17L)
         expect_identical(dim(f1), dim(f2))
     })
@@ -122,7 +122,7 @@ with_test_authentication({
 
     ## Assert those things
     expect_fork_edits <- function (dataset) {
-        expect_output(exclusion(dataset), "v3 < 11")
+        expect_prints(exclusion(dataset), "v3 < 11")
         expect_identical(dim(dataset), c(17L, 8L))
         expect_identical(names(na.omit(categories(dataset$v4))),
             c("d", "e", "F"))

--- a/tests/testthat/test-geo.R
+++ b/tests/testthat/test-geo.R
@@ -10,21 +10,21 @@ with_mock_crunch({
         expect_equal(geo_data$geodatum,
                      "https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/")
     })
-    
+
     test_that("is.Geodata", {
         expect_true(is.Geodata(Geodata(crGET("https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/"))))
     })
-    
+
     test_that("if there is no geography on a variable, geo() returns null", {
         expect_null(geo(ds$gender))
     })
-    
+
     test_that("can remove a geo association", {
         expect_PATCH(geo(ds$location) <- NULL,
                      'https://app.crunch.io/api/datasets/1/variables/location/',
                      '{"element":"shoji:entity","body":{"view":{"geodata":[]}}}')
     })
-    
+
     test_that("we can update individual fiels of the geography", {
         expect_PATCH(geo(ds$location)$feature_key <- "properties.location2",
                      'https://app.crunch.io/api/datasets/1/variables/location/',
@@ -53,9 +53,9 @@ with_mock_crunch({
                      ',"feature_key":"properties.location","match_field":"name"}]}}'
         )
     })
-    
+
     avail_features <- availableGeodataFeatures()
-    # make up new features to simulate a situation where multiple 
+    # make up new features to simulate a situation where multiple
     # geographies match
     # double the geos
     new_features <- avail_features
@@ -66,9 +66,9 @@ with_mock_crunch({
     new_features$property <- paste0(new_features$property, "_new")
     new_features$geodatum <- paste0(new_features$geodatum, "_new")
     lots_n_lots_o_features <- rbind(lots_o_features, new_features)
-    
+
     guesses <- c("foo", "bar", "Scotland", "North", "Midlands", "London")
-    
+
     test_that("availableFeatures", {
         expect_is(avail_features, "data.frame")
         expect_equal(dim(avail_features), c(51, 6))
@@ -78,20 +78,20 @@ with_mock_crunch({
                          "London", "Wales", "Scotland", "Northern Ireland",
                          "Midlands", "South", "North",
                          # new one geodatum
-                         "test", 
+                         "test",
                          # Duplicate properties geodatum
                          rep(c("w", "n", "x", "b", "q", "s", "l", "v", "y", "m",
                                "t", "e", "z", "k", "i", "h", "c"), 2),
                          "totally", "different"))
-        
+
     })
-    
+
     test_that("scoreCatToFeat", {
         # check the score for guesses and mock available features is accurate
         features <- subset(avail_features, property == "name")$value
         expect_equal(scoreCatToFeat(features, guesses), 0.4)
     })
-    
+
     test_that("matchCatToFeat", {
         # There should be only one match, and it should be on property.name
         matches <- matchCatToFeat(guesses, all_features = avail_features)
@@ -100,7 +100,7 @@ with_mock_crunch({
         expect_equal(matches$value, 0.4)
         expect_equal(as.character(matches$property), "name")
     })
-    
+
     test_that("multiMatchHelper deals with multiple geo features gracefully.", {
         matches <- matchCatToFeat(guesses, all_features = lots_o_features)
         match_msg <- multiMatchHelper(matches, "name", "var")
@@ -158,7 +158,7 @@ with_mock_crunch({
                             " feature_key='properties.name_new_new',\n",
                             "                   match_field='name')\n\n"))
     })
-    
+
     test_that("addGeoMetadata", {
         # full run of adding geometadata including guessing the geodata to use
         geo_to_add <- addGeoMetadata(ds$location)
@@ -168,11 +168,11 @@ with_mock_crunch({
         expect_equal(geo_to_add$geodatum,
                      "https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/")
     })
-    
+
     test_that("addGeoMetadata adds the first property if more than one matches", {
-        # if there is more than one property on a single geodatum that matches, 
+        # if there is more than one property on a single geodatum that matches,
         # just use the first property.
-        expect_warning(geo_to_add <- addGeoMetadata(ds$textVar), 
+        expect_warning(geo_to_add <- addGeoMetadata(ds$textVar),
                        paste0("The geodatum ", dQuote("Duplicate properties"),
                               " has multiple properties that match the variable \\(",
                               dQuote("first_name"), " and ", dQuote("second_name"),
@@ -183,9 +183,9 @@ with_mock_crunch({
         expect_equal(geo_to_add$geodatum,
                      "https://app.crunch.io/api/geodata/duplicate_prop/")
     })
-    
+
     test_that("addGeoMetadata tries to help if there are multiple matches", {
-        # if there is more than one property on a single geodatum that matches, 
+        # if there is more than one property on a single geodatum that matches,
         # just use the first property.
         expect_error(geo_to_add <- addGeoMetadata(ds$location,
                                                   all_features = lots_o_features),
@@ -211,11 +211,11 @@ with_mock_crunch({
                          "                   match_field='name')\n\n"
                      ),
                      fixed = TRUE)
-        
+
     })
-    
-    
-    
+
+
+
     test_that("addGeoMetadata input validation", {
         # adding dQuote("ds$not_a_var") to error string inexplicably doesn't
         # match with testthat
@@ -228,17 +228,17 @@ with_mock_crunch({
                      paste0("None of the geographies match at all. Either the variable is",
                             " wrong, or Crunch doesn't yet have geodata for this variable."))
     })
-    
+
     test_that("CrunchGeography show methods", {
-        expect_output(geo_data,
-                      paste0("CrunchGeography metadata for variable \\\n",
-                             "geodatum name: 		GB Regions\\\n",
-                             "geodatum description: 	These are the GB regions\\\n",
-                             "geodatum url: 		https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/\\\n",
-                             "feature_key: 		properties.location\\\n",
-                             "match_field: 		name"))
+        expect_prints(geo_data,
+                      paste("CrunchGeography metadata for variable ",
+                             "geodatum name: 		GB Regions",
+                             "geodatum description: 	These are the GB regions",
+                             "geodatum url: 		https://app.crunch.io/api/geodata/8684c65ff11c4cc3b945c0cf1c9b2a7f/",
+                             "feature_key: 		properties.location",
+                             "match_field: 		name", sep="\n"))
     })
-    
+
     test_that("Geodata methods", {
         gd <- Geodata(crGET(geo_data$geodatum))
         expect_is(gd, "Geodata")
@@ -271,32 +271,34 @@ with_test_authentication({
     #                 "location" = "https://s.crunch.io/geodata/crunch-io/cb_2015_us_region_20m.topojson",
     #                 "owner_id" = "00002")
     # crPOST("http://local.crunch.io:8080/api/geodata/", body=toJSON(payload))
-    
+
     geo_ds <- newDataset(df)
     test_that("Can match and set geodata on a text variable", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
         geo_ds$region <- rep(c("South", "West", "West", "South", "West"), 4)
         expect_silent(geo_ds$region <- addGeoMetadata(geo_ds$region))
-        expect_output(geo(geo_ds$region),
+        expect_prints(geo(geo_ds$region),
                       paste0("geodatum name: 		US Census Regions\\\n",
                              "geodatum description: 	Census regions\\\n",
                              "geodatum url: 		.*\\\n", # the geodatum id will change, so the url will change.
                              "feature_key: 		properties.name\\\n",
-                             "match_field: 		name"))
+                             "match_field: 		name"),
+                      fixed=FALSE)
     })
-    
+
     test_that("Can match and set geodata on a categorical variable", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
         geo_ds$region2 <- factor(rep(c("South", "West", "West", "South", "West"), 4))
         expect_silent(geo_ds$region2 <- addGeoMetadata(geo_ds$region2))
-        expect_output(geo(geo_ds$region2),
+        expect_prints(geo(geo_ds$region2),
                       paste0("geodatum name: 		US Census Regions\\\n",
                              "geodatum description: 	Census regions\\\n",
                              "geodatum url: 		.*\\\n", # the geodatum id will change, so the url will change.
                              "feature_key: 		properties.name\\\n",
-                             "match_field: 		name"))
+                             "match_field: 		name"),
+                      fixed=FALSE)
     })
-    
+
     geo_ds$state <- rep(c("Alabama", "Alaska", "Arizona", "Arkansas", "California"), 4)
     test_that("There is an error if more than one geography matches", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
@@ -314,7 +316,7 @@ with_test_authentication({
         expect_is(geo(geo_ds$state), "CrunchGeography")
         expect_identical(geo(geo_ds$state), new_geo)
     })
-    
+
     test_that("can remove a geo association", {
         skip_locally("Vagrant doesn't currently have hosted geodata")
         expect_silent(geo(geo_ds$state) <- NULL)

--- a/tests/testthat/test-insertions.R
+++ b/tests/testthat/test-insertions.R
@@ -68,12 +68,12 @@ test_that("Insertion validation", {
 })
 
 test_that("Insertion and insertions show methods", {
-    expect_output(insrt,
+    expect_prints(insrt,
                   get_output(data.frame(anchor=c(6),
                                         name=c("Low"),
                                         func=c("subtotal"),
                                         args=c("1 and 2"))))
-    expect_output(insrts,
+    expect_prints(insrts,
                   get_output(data.frame(anchor=c(6, 7),
                                         name=c("Low", "High"),
                                         func=c("subtotal", "subtotal"),
@@ -85,7 +85,7 @@ test_that("Insertion and insertions show methods with hetrogeneous insertions", 
                                   categories = c("A", "B")),
                          Heading(name = "The end", after = "D"))
 
-    expect_output(insrts,
+    expect_prints(insrts,
                   get_output(data.frame(
                      anchor = c("B", "D"),
                      name = c("Cats A+B", "The end"),

--- a/tests/testthat/test-merge-datasets.R
+++ b/tests/testthat/test-merge-datasets.R
@@ -150,7 +150,7 @@ with_test_authentication({
     with_consent(ds1$allpets_1 <- NULL)
     ds2 <- newDatasetFromFixture("apidocs2")
     test_that("Shape of apidocs2", {
-        expect_output(ordering(ds2),
+        expect_prints(ordering(ds2),
             paste(printed_order_apidocs2, collapse="\n"), fixed=TRUE)
         expect_identical(names(ds2), c("allpets", "q1", "petloc", "ndogs",
             "ndogs_a", "ndogs_b", "q3", "country", "wave", "stringid"))
@@ -165,7 +165,7 @@ with_test_authentication({
         ds1 <- merge(ds1, ds2, by.x=ds1$id, by.y=ds2$stringid)
         expect_is(ds1, "CrunchDataset")
         expect_identical(dim(ds1), c(14L, 12L))
-        expect_output(ordering(ds1),
+        expect_prints(ordering(ds1),
             paste(c(
                 "ID",
                 "Join matches",
@@ -196,7 +196,7 @@ with_test_authentication({
             "Variable caseid is hidden")
         expect_is(ds1, "CrunchDataset")
         expect_identical(dim(ds1), c(14L, 13L))
-        expect_output(ordering(ds1),
+        expect_prints(ordering(ds1),
             paste(c(
                 "ID",
                 "Join matches",
@@ -232,7 +232,7 @@ with_test_authentication({
         with_consent(ds1$allpets_1 <- NULL)
         ds1 <- merge(ds1, ds2[ds2$stringid == "43805958", c("stringid", "q1", "petloc")],
             by.x="id", by.y="stringid")
-        expect_output(ordering(ds1),
+        expect_prints(ordering(ds1),
                       paste(c(
                           "ID",
                           "Join matches",
@@ -269,7 +269,7 @@ with_test_authentication({
         with_consent(ds1$allpets_1 <- NULL)
         ds1 <- merge(ds1, ds2[ds2$stringid == "43805958",],
             by.x="id", by.y="stringid")
-        expect_output(ordering(ds1),
+        expect_prints(ordering(ds1),
                       paste(c(
                           "ID",
                           "Join matches",

--- a/tests/testthat/test-multitables.R
+++ b/tests/testthat/test-multitables.R
@@ -127,7 +127,7 @@ with_mock_crunch({
                                     name="Shared multitable")
             expect_is(mtable, "Multitable")
         })
-        expect_output(mtable,
+        expect_prints(mtable,
                       paste(paste0("Multitable ", dQuote("Shared multitable")),
                                    "Column variables:",
                                    "  gender",
@@ -211,7 +211,7 @@ with_mock_crunch({
                 .Dimnames=list(
                     c("Admitted", "Rejected"),
                     c("", "A", "B", "C", "D", "E", "F", "Male", "Female")))
-            expect_output(print(book[[1]]), get_output(out))
+            expect_prints(print(book[[1]]), get_output(out))
             ## TODO: print method for TabBookResult
         })
         test_that("The first result in a MultitableResult has 2 dimensions", {

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -4,7 +4,7 @@ with_mock_crunch({
     test_that("If progress polling gives up, it tells you what to do", {
         with(temp.option(crunch.timeout=0.0005), {
             expect_error(
-                expect_output(pollProgress("https://app.crunch.io/api/progress/1/", wait=0.001),
+                expect_prints(pollProgress("https://app.crunch.io/api/progress/1/", wait=0.001),
                     "|================"),
                 paste('Your process is still running on the server. It is',
                     'currently 23% complete. Check',
@@ -37,7 +37,7 @@ with_mock_crunch({
                 status_code=200, headers=list(`Content-Type`="application/json")))
         },
         test_that("Progress polling goes until 100 and has a newline", {
-            ## Use capture.output rather than expect_output because the latter
+            ## Use capture.output rather than expect_prints because the latter
             ## concatenates things together and does not easily capture the effect
             ## of closing the progress bar, which is another item on the buffer.
             out <- capture.output(
@@ -51,7 +51,7 @@ with_mock_crunch({
             counter <<- 1
             logfile <- tempfile()
             with(temp.option(httpcache.log=logfile), {
-                expect_output(
+                expect_prints(
                     expect_identical(handleAPIresponse(fakeProg("https://app.crunch.io/api/progress/")),
                         "https://app.crunch.io/api/datasets/"),
                     "=| 100%", fixed=TRUE)
@@ -74,7 +74,7 @@ with_mock_crunch({
             counter <<- 1
             logfile <- tempfile()
             with(temp.option(httpcache.log=logfile), {
-                expect_output(
+                expect_prints(
                     expect_message(
                         expect_error(handleAPIresponse(fakeProg("https://app.crunch.io/api/progress2/")),
                             paste("Education, Commerce, and, uh, oops."), fixed=TRUE),

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -4,7 +4,7 @@ with_mock_crunch({
     test_that("If progress polling gives up, it tells you what to do", {
         with(temp.option(crunch.timeout=0.0005), {
             expect_error(
-                expect_prints(pollProgress("https://app.crunch.io/api/progress/1/", wait=0.001),
+                expect_output(pollProgress("https://app.crunch.io/api/progress/1/", wait=0.001),
                     "|================"),
                 paste('Your process is still running on the server. It is',
                     'currently 23% complete. Check',
@@ -37,7 +37,7 @@ with_mock_crunch({
                 status_code=200, headers=list(`Content-Type`="application/json")))
         },
         test_that("Progress polling goes until 100 and has a newline", {
-            ## Use capture.output rather than expect_prints because the latter
+            ## Use capture.output rather than expect_output because the latter
             ## concatenates things together and does not easily capture the effect
             ## of closing the progress bar, which is another item on the buffer.
             out <- capture.output(
@@ -51,7 +51,7 @@ with_mock_crunch({
             counter <<- 1
             logfile <- tempfile()
             with(temp.option(httpcache.log=logfile), {
-                expect_prints(
+                expect_output(
                     expect_identical(handleAPIresponse(fakeProg("https://app.crunch.io/api/progress/")),
                         "https://app.crunch.io/api/datasets/"),
                     "=| 100%", fixed=TRUE)
@@ -74,7 +74,7 @@ with_mock_crunch({
             counter <<- 1
             logfile <- tempfile()
             with(temp.option(httpcache.log=logfile), {
-                expect_prints(
+                expect_output(
                     expect_message(
                         expect_error(handleAPIresponse(fakeProg("https://app.crunch.io/api/progress2/")),
                             paste("Education, Commerce, and, uh, oops."), fixed=TRUE),

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -109,7 +109,7 @@ with_mock_crunch({
     })
 
     test_that("Print method for MemberCatalog", {
-        expect_output(m,
+        expect_prints(m,
             get_output(data.frame(
                 name=c("Fake User", "Roger User"),
                 email=c("fake.user@example.com", "roger.user@example.com"),
@@ -143,7 +143,7 @@ with_mock_crunch({
         expect_is(do, "DatasetOrder")
         expect_identical(do@graph,
             list(DatasetGroup("Group 1", "https://app.crunch.io/api/datasets/3/")))
-        expect_output(do,
+        expect_prints(do,
             paste("[+] Group 1", "    ECON.sav", sep="\n"), fixed=TRUE)
     })
 
@@ -311,7 +311,7 @@ with_test_authentication({
         expect_identical(ordering(datasets(tp))@graph[[1]],
             DatasetGroup(name="A group of two",
             entities=c(self(ds), self(ds3))))
-        expect_output(ordering(datasets(tp)),
+        expect_prints(ordering(datasets(tp)),
             paste("[+] A group of two",
                   paste0("    ", name(ds)),
                   paste0("    ", name(ds3)),
@@ -334,7 +334,7 @@ with_test_authentication({
 
     test_that("Can create a Group by assigning by name", {
         ordering(datasets(tp))[["New group three"]] <- self(ds)
-        expect_output(ordering(datasets(tp)),
+        expect_prints(ordering(datasets(tp)),
             paste("[+] G1",
                   paste0("    ", name(ds3)),
                   "[+] G2",

--- a/tests/testthat/test-subtotals-and-headings.R
+++ b/tests/testthat/test-subtotals-and-headings.R
@@ -216,7 +216,7 @@ with_test_authentication({
 
         expect_json_equivalent(transforms(ds$v4), trans_resp)
 
-        expect_output(subtotals(ds$v4),
+        expect_prints(subtotals(ds$v4),
                       get_output(data.frame(
                           anchor = c("top", 1, 2, "bottom"),
                           name = c("This is a subtitle","B alone","C alone", "B+C"),

--- a/tests/testthat/test-variable-catalog.R
+++ b/tests/testthat/test-variable-catalog.R
@@ -93,7 +93,7 @@ with_mock_crunch({
     })
 
     test_that("show method", {
-        expect_output(varcat[1:4],
+        expect_prints(varcat[1:4],
             get_output(data.frame(
                 alias=c("birthyr", "gender", "location", "mymrset"),
                 name=c("Birth Year", "Gender", "Categorical Location", "mymrset"),

--- a/tests/testthat/test-variable-folders.R
+++ b/tests/testthat/test-variable-folders.R
@@ -125,7 +125,7 @@ with_mock_crunch({
         with(temp.option(crayon.enabled=FALSE), {
             ## Coloring aside, the default print method should look like you
             ## printed the vector of names (plus the path printed above)
-            testthat::expect_output(print(folders(ds)),
+            expect_output(print(folders(ds)),
                 capture.output(print(names(folders(ds)))), fixed=TRUE)
             ## These are obfuscated because of archaic restrictions on UTF-8
             skip_on_cran()

--- a/tests/testthat/test-variable-order.R
+++ b/tests/testthat/test-variable-order.R
@@ -307,12 +307,12 @@ with_mock_crunch({
 
     ds3 <- loadDataset("ECON.sav")
     test_that("Show method for VO handles relative URLs correctly", {
-        expect_output(ordering(ds3),
+        expect_prints(ordering(ds3),
             "Gender\nBirth Year\nstarttime")
     })
 
     test_that("VariableOrder/Group show methods", {
-        expect_output(nested.ord,
+        expect_prints(nested.ord,
             paste("[+] Group 1",
                   "    Birth Year",
                   "    [+] Nested",
@@ -327,7 +327,7 @@ with_mock_crunch({
             fixed=TRUE)
         no <- nested.ord
         no[[3]] <- VariableGroup("Group 3", entities=list())
-        expect_output(no,
+        expect_prints(no,
             paste("[+] Group 1",
                   "    Birth Year",
                   "    [+] Nested",
@@ -344,7 +344,7 @@ with_mock_crunch({
             fixed=TRUE)
     })
     test_that("Printing a single group doesn't fail (though it probably should do better than show URLs)", {
-        expect_output(nested.ord[[2]],
+        expect_prints(nested.ord[[2]],
             paste("[+] Group 2",
                   "    https://app.crunch.io/api/datasets/1/variables/starttime/",
                   "    https://app.crunch.io/api/datasets/1/variables/catarray/",
@@ -354,7 +354,7 @@ with_mock_crunch({
 
     ord <- flattenOrder(test.ord)
     test_that("Composing a VariableOrder step by step: setup (flattenOrder)", {
-        expect_output(ord,
+        expect_prints(ord,
             paste("Birth Year",
                   "Gender",
                   "Categorical Location",
@@ -367,7 +367,7 @@ with_mock_crunch({
     })
     test_that("Composing a VariableOrder step by step: group 1 by dataset", {
         ord$Demos <<- ds[c("gender", "birthyr")]
-        expect_output(ord,
+        expect_prints(ord,
             paste("Categorical Location",
                   "mymrset",
                   "Text variable ftw",
@@ -381,7 +381,7 @@ with_mock_crunch({
     })
     test_that("Composing a VariableOrder step by step: group by Order subset", {
         ord$Arrays <<- ord[c(2, 5)] #ds[c("mymrset", "catarray")]
-        expect_output(ord,
+        expect_prints(ord,
             paste("Categorical Location",
                   "Text variable ftw",
                   "starttime",
@@ -396,7 +396,7 @@ with_mock_crunch({
     })
     test_that("Composing a VariableOrder step by step: nested group by dataset", {
         ord$Demos[["Others"]] <<- ds[c("birthyr", "textVar")]
-        expect_output(ord,
+        expect_prints(ord,
             paste("Categorical Location",
                   "starttime",
                   "[+] Demos",
@@ -412,7 +412,7 @@ with_mock_crunch({
     })
     test_that("Composing a VariableOrder step by step: reorder group", {
         ord$Demos <<- ord$Demos[2:1]
-        expect_output(ord,
+        expect_prints(ord,
             paste("Categorical Location",
                   "starttime",
                   "[+] Demos",
@@ -428,7 +428,7 @@ with_mock_crunch({
     })
     test_that("Composing a VariableOrder step by step: reorder order", {
         ord <<- ord[4:1]
-        expect_output(ord,
+        expect_prints(ord,
             paste("[+] Arrays",
                   "    mymrset",
                   "    Cat Array",
@@ -444,7 +444,7 @@ with_mock_crunch({
     })
     test_that("Composing a VariableOrder step by step: nested group by Group", {
         ord$Arrays$MR <<- ord$Arrays[1]
-        expect_output(ord,
+        expect_prints(ord,
             paste("[+] Arrays",
                   "    Cat Array",
                   "    [+] MR",
@@ -462,7 +462,7 @@ with_mock_crunch({
 
     test_that("Order print method follows namekey", {
         with(temp.option(crunch.namekey.variableorder="alias"), {
-            expect_output(ord,
+            expect_prints(ord,
                 paste("[+] Arrays",
                       "    catarray",
                       "    [+] MR",
@@ -490,7 +490,7 @@ with_mock_crunch({
 
     test_that("Composing a VariableOrder step by step: moveToGroup", {
         moveToGroup(ord$Demos$Others) <<- ds$starttime
-        expect_output(ord,
+        expect_prints(ord,
             paste("[+] Arrays",
                   "    Cat Array",
                   "    [+] MR",
@@ -509,7 +509,7 @@ with_mock_crunch({
     test_that("moveToGroup with groups", {
         moveToGroup(ord$Demos) <<- ord$Arrays
         ord <- removeEmptyGroups(ord)
-        expect_output(ord,
+        expect_prints(ord,
             paste("[+] Demos",
                   "    [+] Others",
                   "        Birth Year",
@@ -526,7 +526,7 @@ with_mock_crunch({
     test_that("moveToGroup with dataset subset", {
         moveToGroup(ord$Demos$Arrays) <<- ds[c("birthyr", "gender")]
         ord <- removeEmptyGroups(ord)
-        expect_output(ord,
+        expect_prints(ord,
             paste("[+] Demos",
                   "    [+] Others",
                   "        Text variable ftw",
@@ -541,7 +541,7 @@ with_mock_crunch({
             fixed=TRUE)
     })
     test_that("flattenOrder on that composed order", {
-        expect_output(flattenOrder(ord),
+        expect_prints(flattenOrder(ord),
             paste("Text variable ftw",
                   "starttime",
                   "Cat Array",
@@ -575,7 +575,7 @@ with_mock_crunch({
         catalog_url=varcat_url
     )
     test_that("Complex order with duplicates", {
-        expect_output(ord,
+        expect_prints(ord,
             paste("[+] Alpha",
                   "    Gender",
                   "    [+] Bravo",
@@ -602,7 +602,7 @@ with_mock_crunch({
             fixed=TRUE)
     })
     test_that("dedupeOrder removes duplicate entries", {
-        expect_output(dedupeOrder(ord),
+        expect_prints(dedupeOrder(ord),
             paste("[+] Alpha",
                   "    [+] Bravo",
                   "        [+] Charlie",
@@ -619,7 +619,7 @@ with_mock_crunch({
             fixed=TRUE)
     })
     test_that("dedupeOrder doesn't mutate an order that's already deduped", {
-        expect_output(dedupeOrder(dedupeOrder(ord)),
+        expect_prints(dedupeOrder(dedupeOrder(ord)),
             paste("[+] Alpha",
                   "    [+] Bravo",
                   "        [+] Charlie",
@@ -637,7 +637,7 @@ with_mock_crunch({
     })
     test_that("Setting duplicates <- FALSE triggers dedupeOrder", {
         duplicates(ord) <- FALSE
-        expect_output(ord,
+        expect_prints(ord,
             paste("[+] Alpha",
                   "    [+] Bravo",
                   "        [+] Charlie",
@@ -654,7 +654,7 @@ with_mock_crunch({
             fixed=TRUE)
     })
     test_that("intersect_entities", {
-        expect_output(intersect_entities(ord, ds[c("birthyr", "starttime")]),
+        expect_prints(intersect_entities(ord, ds[c("birthyr", "starttime")]),
             paste("[+] Alpha",
                   "    [+] Bravo",
                   "        [+] Charlie",

--- a/tests/testthat/test-variable-transforms.R
+++ b/tests/testthat/test-variable-transforms.R
@@ -159,7 +159,7 @@ with_mock_crunch({
         loc_ary <- array(c(7, 10, 17), dim = 3,
                          dimnames = list(c("London", "Scotland",
                                            "London+Scotland")))
-        expect_output(expect_equivalent(showTransforms(ds$location), loc_ary))
+        expect_prints(expect_equivalent(showTransforms(ds$location), loc_ary))
     })
     
     test_that("Can set transform (with Insertions)", {
@@ -269,7 +269,7 @@ with_test_authentication({
 
         v4_ary <- array(c(10, 10, 20), dim = 3,
                         dimnames = list(c("B", "C", "B+C")))
-        expect_output(expect_equivalent(showTransforms(ds$v4), v4_ary))
+        expect_prints(expect_equivalent(showTransforms(ds$v4), v4_ary))
     })
 
     test_that("Can remove transforms", {
@@ -278,6 +278,6 @@ with_test_authentication({
                             dimnames = list(c("B", "C")))
 
         expect_null(transforms(ds$v4))
-        expect_output(expect_equivalent(showTransforms(ds$v4), v4_notrans))
+        expect_prints(expect_equivalent(showTransforms(ds$v4), v4_notrans))
     })
 })


### PR DESCRIPTION
Add `expect_prints()` instead of overriding `testthat::expect_output()`. (History: `testthat::expect_output()` used to print the objects you passed it but stopped a couple of versions ago. This function overloading was to maintain compatibility across versions.)

Default in `expect_prints` is `fixed=TRUE`, unlike the standard `testthat` functions (including `expect_output`). It seemed that for our needs, regexp matching of output was the exception not the rule. Doing this allowed me to fold the old `expect_fixed_output()` into `expect_prints` too.

Unit/mock tests pass but I didn't have a network connection on the airplane to run the integration tests, so there may be some tests in there that need `fixed=FALSE` added.