### PR TITLE
Distinguish %in% and ==, as they should be

### DIFF
--- a/R/categories.R
+++ b/R/categories.R
@@ -194,7 +194,6 @@ setMethod("is.na<-", c("Categories", "logical"), function (x, value) {
 n2i <- function (x, cats, strict=TRUE) {
     ## Convert x from category names to the corresponding category ids
     out <- ids(cats)[match(x, names(cats))]
-    ## TODO hack: don't drop missing cats, fill with like -1970. see if server chokes
     out <- handleMissingCategoryLookup(out, x, strict)
     return(out)
 }

--- a/R/categories.R
+++ b/R/categories.R
@@ -158,7 +158,7 @@ setMethod("is.selected<-", "Categories", function (x, value) {
     if (length(value) != length(x)) {
         halt("You supplied ", length(value), " logical values for ", length(x), " Categories.")
     }
-    
+
     x@.Data <- mapply(function (x, value) {
         is.selected(x) <- value
         return(x)
@@ -194,6 +194,7 @@ setMethod("is.na<-", c("Categories", "logical"), function (x, value) {
 n2i <- function (x, cats, strict=TRUE) {
     ## Convert x from category names to the corresponding category ids
     out <- ids(cats)[match(x, names(cats))]
+    ## TODO hack: don't drop missing cats, fill with like -1970. see if server chokes
     out <- handleMissingCategoryLookup(out, x, strict)
     return(out)
 }

--- a/R/expressions.R
+++ b/R/expressions.R
@@ -190,7 +190,7 @@ setMethod("!", "CrunchExpr", function (x) zfuncExpr("not", x))
             ## When that is fixed, we can do the following:
             #rep(TRUE, 2L))) ## Inclusive on both sides
     } else {
-        return(zfunc(ifelse(length(table) == 1, "==", "in"), x, table))
+        return(zfunc(ifelse(length(table) == 1L, "==", "in"), x, table))
     }
 }
 

--- a/R/expressions.R
+++ b/R/expressions.R
@@ -194,7 +194,7 @@ setMethod("!", "CrunchExpr", function (x) zfuncExpr("not", x))
     }
 }
 
-.inCrunch <- function (x, table) math.exp(x, r2zcl(I(table)), "in")
+.inCrunch <- function (x, table) zfuncExpr("selected", math.exp(x, r2zcl(I(table)), "in"))
 
 #' @rdname expressions
 #' @export

--- a/R/expressions.R
+++ b/R/expressions.R
@@ -247,7 +247,7 @@ for (i in c("==", "!=")) {
 #' @export
 setMethod("==", c("CategoricalVariable", "numeric"), function (e1, e2) {
     if (length(e2) == 0) {
-        ## The specified category was doesn't exist. But ``== BAD` breaks server
+        ## The specified category doesn't exist. But `== BAD` breaks server
         ## However, "in []" is fine
         return(math.exp(e1, e2, "in"))
     }

--- a/R/show.R
+++ b/R/show.R
@@ -197,6 +197,9 @@ formatExpression <- function (expr) {
             return(paste0("!", args[1]))
         } else if (func %in% .operators) {
             return(paste(args[1], func, args[2]))
+        } else if (func == "selected" && grepl("%in%", args[1])) {
+            ## R's %in% is Crunch's selected(in()) wrt missing data handling
+            return(args[1])
         } else {
             return(paste0(func, "(", paste(args, collapse=", "), ")"))
         }

--- a/R/zcl.R
+++ b/R/zcl.R
@@ -6,15 +6,18 @@ r2zcl <- function (x) {
     v <- toVariable(x)
     attributes(v$values) <- NULL
 
-    ## If there is a single value, call it "value". Else it is a "column" array
-    if (length(x) == 1) {
-        out <- list(value=v$values)
+    ## "column" if we're sending an array. If scalar, it is "value"
+    if (length(x) != 1) {
+        out <- as.zcl(column=v$values)
+    } else if (inherits(x, "AsIs")) {
+        out <- as.zcl(column=I(v$values))
     } else {
-        out <- list(column=v$values)
+        out <- as.zcl(value=v$values)
     }
-
     return(out)
 }
+
+as.zcl <- function (...) structure(list(...), class="zcl")
 
 ## Methods to convert various objects to ZCL
 setMethod("zcl", "CrunchExpr", function (x) x@expression)

--- a/man/expressions.Rd
+++ b/man/expressions.Rd
@@ -13,8 +13,10 @@
 \alias{\%in\%,DatetimeVariable,POSIXt-method}
 \alias{\%in\%,DatetimeVariable,character-method}
 \alias{\%in\%,CategoricalVariable,numeric-method}
+\alias{==,CategoricalVariable,numeric-method}
 \alias{==,CategoricalVariable,character-method}
 \alias{==,CategoricalVariable,factor-method}
+\alias{!=,CategoricalVariable,numeric-method}
 \alias{!=,CategoricalVariable,character-method}
 \alias{!=,CategoricalVariable,factor-method}
 \alias{is.na,CrunchVariable-method}
@@ -42,9 +44,13 @@
 
 \S4method{\%in\%}{CategoricalVariable,numeric}(x, table)
 
+\S4method{==}{CategoricalVariable,numeric}(e1, e2)
+
 \S4method{==}{CategoricalVariable,character}(e1, e2)
 
 \S4method{==}{CategoricalVariable,factor}(e1, e2)
+
+\S4method{!=}{CategoricalVariable,numeric}(e1, e2)
 
 \S4method{!=}{CategoricalVariable,character}(e1, e2)
 

--- a/tests/testthat/test-combine-categories.R
+++ b/tests/testthat/test-combine-categories.R
@@ -147,7 +147,11 @@ with_mock_crunch({
     test_that("collapseCategories updates the variable", {
         expect_POST(var <- collapseCategories(ds$location, "Scotland", "London"),
             "https://app.crunch.io/api/datasets/1/table/",
-            '{"command":"update","variables":{"https://app.crunch.io/api/datasets/1/variables/location/":{"value":1}},"filter":{"function":"==","args":[{"variable":"https://app.crunch.io/api/datasets/1/variables/location/"},{"value":2}]}}'
+            '{"command":"update","variables":{',
+            '"https://app.crunch.io/api/datasets/1/variables/location/":{"value":1}},',
+            '"filter":{"function":"in","args":[',
+            '{"variable":"https://app.crunch.io/api/datasets/1/variables/location/"},',
+            '{"column":[2]}]}}'
         )
     })
     test_that("collapseCategories modifies category name", {

--- a/tests/testthat/test-combine-categories.R
+++ b/tests/testthat/test-combine-categories.R
@@ -149,9 +149,9 @@ with_mock_crunch({
             "https://app.crunch.io/api/datasets/1/table/",
             '{"command":"update","variables":{',
             '"https://app.crunch.io/api/datasets/1/variables/location/":{"value":1}},',
-            '"filter":{"function":"in","args":[',
+            '"filter":{"function":"selected","args":[{"function":"in","args":[',
             '{"variable":"https://app.crunch.io/api/datasets/1/variables/location/"},',
-            '{"column":[2]}]}}'
+            '{"column":[2]}]}]}}'
         )
     })
     test_that("collapseCategories modifies category name", {

--- a/tests/testthat/test-exclusion-filter.R
+++ b/tests/testthat/test-exclusion-filter.R
@@ -5,7 +5,7 @@ with_mock_crunch({
     ds2 <- loadDataset("ECON.sav")
 
     test_that("Get exclusions", {
-        expect_equal(exclusion(ds), ds$birthyr < 0)
+        expect_equivalent(exclusion(ds), ds$birthyr < 0)
         expect_null(exclusion(ds2))
     })
     test_that("Set exclusion", {

--- a/tests/testthat/test-expressions.R
+++ b/tests/testthat/test-expressions.R
@@ -215,7 +215,7 @@ with_test_authentication({
             c(8, 10, 12))
     })
 
-    test_that("expressions on expresssions evaluate", {
+    test_that("expressions on expressions evaluate", {
         e3 <- ds$v3 + ds$v3 + 10
         expect_is(e3, "CrunchExpr")
         expect_prints(e3, "Crunch expression: v3 + v3 + 10")

--- a/tests/testthat/test-expressions.R
+++ b/tests/testthat/test-expressions.R
@@ -32,7 +32,7 @@ with_mock_crunch({
                 list(value=5)
             )
         )
-        expect_identical(zcl(e1), zexp)
+        expect_equivalent(zcl(e1), zexp)
         expect_prints(e1, "Crunch expression: birthyr + 5")
         e2 <- 5 + ds$birthyr
         expect_is(e2, "CrunchExpr")
@@ -80,9 +80,9 @@ with_mock_crunch({
         expect_prints(ds$gender == as.factor("Male"),
             'Crunch logical expression: gender == "Male"')
         expect_prints(ds$gender %in% "Male",
-            'Crunch logical expression: gender == "Male"')
+            'Crunch logical expression: gender %in% "Male"')
         expect_prints(ds$gender %in% as.factor("Male"),
-            'Crunch logical expression: gender == "Male"')
+            'Crunch logical expression: gender %in% "Male"')
         expect_prints(ds$gender %in% c("Male", "Female"),
             'Crunch logical expression: gender %in% c("Male", "Female")')
         expect_prints(ds$gender %in% as.factor(c("Male", "Female")),
@@ -99,7 +99,7 @@ with_mock_crunch({
             paste("Category not found:", dQuote("other")))
         expect_warning(
             expect_prints(ds$gender %in% c("other", "Male", "another"),
-                'Crunch logical expression: gender == "Male"'),
+                'Crunch logical expression: gender %in% "Male"'),
             paste("Categories not found:", dQuote("other"), "and",
                 dQuote("another")))
         expect_warning(
@@ -116,7 +116,7 @@ with_mock_crunch({
         expect_prints(ds$birthyr == 1945 | ds$birthyr < 1941,
             'birthyr == 1945 | birthyr < 1941')
         expect_prints(ds$gender %in% "Male" & !is.na(ds$birthyr),
-            'gender == "Male" & !is.na(birthyr)')
+            'gender %in% "Male" & !is.na(birthyr)')
         expect_prints(!(ds$gender == "Male"),
             'Crunch logical expression: !gender == "Male"')
             ## TODO: better parentheses for ^^
@@ -187,7 +187,7 @@ with_test_authentication({
             })
         })
     })
-    
+
     test_that("Logical expressions evaluate", {
         e1 <- ds$v3 > 10
         expect_is(e1, "CrunchLogicalExpr")
@@ -202,7 +202,7 @@ with_test_authentication({
         expect_identical(as.vector(e2)[na_filt], df[na_filt,]$v2 == "a")
         expect_identical(which(e2), which(df$v2 == "a"))
     })
-    
+
     test_that("R & Crunch logical together", {
         e1 <- ds$v3 < 10 | c(rep(FALSE, 15), rep(TRUE, 5))
         expect_equivalent(as.vector(ds$v3[e1]),

--- a/tests/testthat/test-zcl.R
+++ b/tests/testthat/test-zcl.R
@@ -1,0 +1,7 @@
+context("ZCL expressions")
+
+test_that("r2zcl cases", {
+    expect_identical(r2zcl(4), as.zcl(value=4))
+    expect_identical(r2zcl(c(4, 6)), as.zcl(column=c(4, 6)))
+    expect_identical(r2zcl(I(4)), as.zcl(column=I(4)))
+})


### PR DESCRIPTION
And map %in% to `selected`, the new function that will drop missingness, just as `%in%` does in R.