### PR TITLE
makeMRFromText categorical bug

### DIFF
--- a/R/make-array.R
+++ b/R/make-array.R
@@ -111,11 +111,12 @@ makeMRFromText <- function (var,
     if (missing(name)) {
         halt("Must supply a name for the new variable")
     }
-    if (is.Categorical(var) || is.Text(var)) {
+    if (is.Text(var)) {
         uniques <- names(table(var))
     } else {
-        halt(dQuote(substitute(var)),
-             " must be a Categorical or Text Crunch Variable.")
+        halt(dQuote(deparse(substitute(var))),
+            " is of class ", class(var),
+             ", it must be a Crunch TextVariable.")
     }
     items <- unique(unlist(strsplit(uniques, delim)))
     # make a derivation expression for each unique item

--- a/tests/testthat/test-make-array.R
+++ b/tests/testthat/test-make-array.R
@@ -61,8 +61,9 @@ with_mock_crunch({
     test_that("makeMRFromText errors correctly", {
         expect_error(makeMRFromText(ds$var, "; "),
             "Must supply a name for the new variable")
-        expect_error(makeMRFromText("string",  name = "name"),
-            paste0(dQuote("string"), " must be a Categorical or Text Crunch Variable."))
+        expect_error(makeMRFromText(ds$birthyr,  name = "name"),
+            paste0(dQuote("ds$birthyr"), " is of class NumericVariable, it must be a Crunch TextVariable."),
+            fixed = TRUE)
     })
 
     test_that("createSubvarDeriv generates the correct variable definition", {


### PR DESCRIPTION
Raise error when user tries to derive an MR from a delimited categorical. This is just a quick fix, and I raised an issue with next steps for this area https://github.com/Crunch-io/rcrunch/issues/246