### PR TITLE
setIndexSlot should check for duplicate URLs

### DIFF
--- a/R/shoji-catalog.R
+++ b/R/shoji-catalog.R
@@ -27,7 +27,7 @@ setIndexSlot <- function (x, i, value, unique=FALSE) {
         ## unique. Make sure that the user isn't trying to assign different
         ## values for the duplicated entries, and if not, clean it up
         if (!scalar_value && !identical(duples, duplicated(paste(urls(x), value)))) {
-            halt("Can't update an index with duplicated entries")
+            halt("Can't update the same index item with more than one entry")
         }
         x <- x[!duples]
         if (!scalar_value) {

--- a/R/shoji-catalog.R
+++ b/R/shoji-catalog.R
@@ -16,8 +16,28 @@ getListSlot <- function (x, i, what=character(1), ifnot=NA_character_) {
 }
 
 setIndexSlot <- function (x, i, value, unique=FALSE) {
-    if (length(value) == 1) value <- rep(value, length(x))
-    stopifnot(length(x) == length(value))
+    scalar_value <- length(value) == 1
+    if (!scalar_value) {
+        stopifnot(length(x) == length(value))
+    }
+
+    duples <- duplicated(urls(x))
+    if (any(duples)) {
+        ## This is probably a mistake, a selection from a catalog that wasn't
+        ## unique. Make sure that the user isn't trying to assign different
+        ## values for the duplicated entries, and if not, clean it up
+        if (!scalar_value && !identical(duples, duplicated(paste(urls(x), value)))) {
+            halt("Can't update an index with duplicated entries")
+        }
+        x <- x[!duples]
+        if (!scalar_value) {
+            value <- value[!duples]
+        }
+    }
+
+    if (scalar_value) {
+        value <- rep(value, length(x))
+    }
 
     old <- index(x)
     index(x) <- mapply(function (a, v) {

--- a/tests/testthat/test-hide-variables.R
+++ b/tests/testthat/test-hide-variables.R
@@ -38,6 +38,10 @@ with_mock_crunch({
         expect_PATCH(ds <- hideVariables(ds, "gender"),
             "https://app.crunch.io/api/datasets/3/variables/",
             '{"https://app.crunch.io/api/datasets/3/variables/gender/":{"discarded":true}}')
+        ## Duplicates are handled
+        expect_PATCH(ds <- hideVariables(ds, c("gender", "gender")),
+            "https://app.crunch.io/api/datasets/3/variables/",
+            '{"https://app.crunch.io/api/datasets/3/variables/gender/":{"discarded":true}}')
         expect_PATCH(ds <- hideVariables(ds, c("gender", "birthyr")),
             "https://app.crunch.io/api/datasets/3/variables/",
             '{"https://app.crunch.io/api/datasets/3/variables/gender/":{"discarded":true}}') ## same

--- a/tests/testthat/test-variable-catalog.R
+++ b/tests/testthat/test-variable-catalog.R
@@ -91,6 +91,19 @@ with_mock_crunch({
             "https://app.crunch.io/api/datasets/1/variables/",
             '{"https://app.crunch.io/api/datasets/1/variables/mymrset/":{"notes":"ms"}}')
     })
+    test_that("attribute setters with duplication", {
+        ## In the first case, the first element is duplicated, but it's getting
+        ## the same value, so we can ignore it
+        expect_PATCH(names(varcat[c(1, 1:4)]) <- c("Year of birth", "Year of birth", "Gender", "Loc", "Start time"),
+            "https://app.crunch.io/api/datasets/1/variables/",
+            '{"https://app.crunch.io/api/datasets/1/variables/birthyr/":{"name":"Year of birth"},',
+            '"https://app.crunch.io/api/datasets/1/variables/location/":{"name":"Loc"},',
+            '"https://app.crunch.io/api/datasets/1/variables/mymrset/":{"name":"Start time"}}')
+        ## In the second case, the first element of the catalog is getting
+        ## assigned two different new values, so that errors.
+        expect_error(names(varcat[c(1, 1:4)]) <- c("Year of birth", "BY", "Gender", "Loc", "Start time"),
+            "Can't update an index with duplicated entries")
+    })
 
     test_that("show method", {
         expect_prints(varcat[1:4],

--- a/tests/testthat/test-variable-catalog.R
+++ b/tests/testthat/test-variable-catalog.R
@@ -102,7 +102,7 @@ with_mock_crunch({
         ## In the second case, the first element of the catalog is getting
         ## assigned two different new values, so that errors.
         expect_error(names(varcat[c(1, 1:4)]) <- c("Year of birth", "BY", "Gender", "Loc", "Start time"),
-            "Can't update an index with duplicated entries")
+            "Can't update the same index item with more than one entry")
     })
 
     test_that("show method", {


### PR DESCRIPTION
See https://www.pivotaltracker.com/story/show/157283138 for an error report and https://crunch-io.slack.com/archives/C8HLAUW23/p1525372333000744 for discussion. Basically, `ds <- hideVariables(ds, c("gender", "gender")` would make an invalid request. This fix adds validation that catches that and some other possible scenarios.