### PR TITLE
Allow conditional transforms with LHSes and RHSes that don't have Crunch expressions

### DIFF
--- a/R/conditional-transform.R
+++ b/R/conditional-transform.R
@@ -158,18 +158,18 @@ makeConditionalValues <- function(formulas, data, else_condition) {
         }
 
         cases[[i]] <- evalLHS(formula, data)
-        if (!inherits(cases[[i]], "CrunchLogicalExpr")) {
-            halt(
-                "The left-hand side provided must be a CrunchLogicalExpr: ",
-                dQuote(LHS_string(formula))
-            )
-        }
+        # if (!inherits(cases[[i]], "CrunchLogicalExpr")) {
+        #     halt(
+        #         "The left-hand side provided must be a CrunchLogicalExpr: ",
+        #         dQuote(LHS_string(formula))
+        #     )
+        # }
         values[[i]] <- evalRHS(formula, data)
     }
 
     # setup NAs for as default
     # check all datasets are the same and get the reference from the unique one
-    ds_refs <- unlist(unique(lapply(cases, datasetReference)))
+    ds_refs <- unlist(unique(lapply(c(cases, values), datasetReference)))
     if (length(ds_refs) > 1) {
         halt(
             "There must be only one dataset referenced. Did you accidentally ",

--- a/R/conditional-transform.R
+++ b/R/conditional-transform.R
@@ -158,22 +158,30 @@ makeConditionalValues <- function(formulas, data, else_condition) {
         }
 
         cases[[i]] <- evalLHS(formula, data)
-        # if (!inherits(cases[[i]], "CrunchLogicalExpr")) {
-        #     halt(
-        #         "The left-hand side provided must be a CrunchLogicalExpr: ",
-        #         dQuote(LHS_string(formula))
-        #     )
-        # }
+        if (!inherits(cases[[i]], c("logical", "CrunchLogicalExpr"))) {
+            halt(
+                "The left-hand side provided must be a logical or a ",
+                "CrunchLogicalExpr: ", dQuote(LHS_string(formula))
+            )
+        }
         values[[i]] <- evalRHS(formula, data)
     }
 
     # setup NAs for as default
     # check all datasets are the same and get the reference from the unique one
     ds_refs <- unlist(unique(lapply(c(cases, values), datasetReference)))
+    if (!missing(data)) {
+        ds_refs <- unique(c(ds_refs, datasetReference(data)))
+    }
     if (length(ds_refs) > 1) {
         halt(
             "There must be only one dataset referenced. Did you accidentally ",
             "supply more than one?"
+        )
+    } else if (length(ds_refs) == 0) {
+        halt(
+            "There must be at least one crunch expression in the formulas ",
+            "specifying cases or use the data argument to specify a dataset."
         )
     }
     n_rows <- nrow(CrunchDataset(crGET(ds_refs)))

--- a/tests/testthat/test-conditional-transform.R
+++ b/tests/testthat/test-conditional-transform.R
@@ -13,9 +13,28 @@ with_mock_crunch({
                 " .*formulas.* argument, or through .*....*"
             )
         )
+               
+        expect_error(
+            conditionalTransform(TRUE ~ "foo"),
+            paste0(
+                "There must be at least one crunch expression in the formulas ",
+                "specifying cases or use the data argument to specify a dataset."
+            )
+        )
+        
+        # but sending the dataset alone does work
+        expect_silent(new_var <- conditionalTransform(TRUE ~ "foo", data = ds))
+        expect_equal(new_var$values, c(
+            c("foo", rep(NA, nrow(ds)-1))
+        ))
+        expect_equal(new_var$type, "text")
+        
         expect_error(
             conditionalTransform("bar" ~ "foo", data = ds),
-            "The left-hand side provided must be a CrunchLogicalExpr: .*bar.*"
+            paste0(
+                "The left-hand side provided must be a logical or a ",
+                "CrunchLogicalExpr: .*bar.*"
+            )
         )
 
         expect_error(


### PR DESCRIPTION
I've loosened the validation, and added some tests. I had to do a bit more work to get the dataset object (it now checks the RHSes, LHSes, and data arugments — one of those must have at least one dataset reference in it — I doubt anyone will run into this because doing `conditionalTransform(TRUE~"foo", name = "my new all foo variable")` is a lot more work than `ds$all_foo <- "foo"` but in case someone finds themselves there).