### PR TITLE
Skip (locally) tests that don't work against a local backend

### DIFF
--- a/tests/testthat/test-crunchbox.R
+++ b/tests/testthat/test-crunchbox.R
@@ -328,6 +328,7 @@ with_test_authentication({
     hiddenVariables(ds) <- "num"
     filters(ds)[["A filter"]] <- ds$cat == "d"
     test_that("We can make a box", {
+        skip_on_local_backend("unskip when #162257432 ships")
         expect_true(is.character(crunchBox(ds)))
     })
 })

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -264,6 +264,7 @@ with_test_authentication({
     test_that("Get and set project icon", {
         ico <- icon(pj)
         # expect_true(nchar(ico) > 0) ## Unskip after #119305641 ships
+        skip_on_local_backend("unskip when #162257432 ships")
         icon(pj) <- "empty.png"
         expect_false(icon(pj) == "empty.png")
         expect_true(endsWith(icon(pj), ".png"))

--- a/tests/testthat/test-user.R
+++ b/tests/testthat/test-user.R
@@ -97,6 +97,7 @@ with_test_authentication({
         user <- index(usercat)[[self(u)]]
         expect_false(user$account_permissions$create_datasets)
         expect_false(user$account_permissions$alter_users)
+        skip("Personal projects block deletes, unskip when 162253630 ships")
         crDELETE(self(u))
         usercat <- refresh(usercat)
         expect_false(u.email %in% emails(usercat))


### PR DESCRIPTION
All skips have corresponding tickets associated with them.