### PR TITLE
dump appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crunch
 
-[![Build Status](https://travis-ci.org/Crunch-io/rcrunch.png?branch=master)](https://travis-ci.org/Crunch-io/rcrunch) [![Build status](https://ci.appveyor.com/api/projects/status/iaydo4y3dfrqnqqu/branch/master?svg=true)](https://ci.appveyor.com/project/nealrichardson/rcrunch/branch/master)
+[![Build Status](https://travis-ci.org/Crunch-io/rcrunch.png?branch=master)](https://travis-ci.org/Crunch-io/rcrunch) 
 [![cran](https://www.r-pkg.org/badges/version-last-release/crunch)](https://cran.r-project.org/package=crunch) [![codecov](https://codecov.io/gh/Crunch-io/rcrunch/branch/master/graph/badge.svg)](https://codecov.io/gh/Crunch-io/rcrunch)
 
 [Cloud Collaboration with Crunch](http://crunch-io.github.io/rcrunch/)


### PR DESCRIPTION
We got rid of this right? We can remove a “build failing” badge?