### PR TITLE
Add filter argument to tabbook

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # crunch (development version)
 * https verification can be disabled during testing by setting environment variable `R_TEST_VERIFY_SSL=FALSE`
+* You can now set a `filter` when using `tabbook()`
 
 # crunch 1.26.3
 * Can now `deriveArray()` using expressions to create the subvariables.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # crunch (development version)
 * https verification can be disabled during testing by setting environment variable `R_TEST_VERIFY_SSL=FALSE`
-* You can now set a `filter` when using `tabbook()` (though documentation used to say that ad-hoc filters worked, this was no longer true and so the documentation was updated)
+* You can now use a named `filter` or `filter` object when using `tabbook()`. Filtering by expression in the dataset argument is also supported again.
 
 # crunch 1.26.3
 * Can now `deriveArray()` using expressions to create the subvariables.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # crunch (development version)
 * https verification can be disabled during testing by setting environment variable `R_TEST_VERIFY_SSL=FALSE`
-* You can now set a `filter` when using `tabbook()`
+* You can now set a `filter` when using `tabbook()` (though documentation used to say that ad-hoc filters worked, this was no longer true and so the documentation was updated)
 
 # crunch 1.26.3
 * Can now `deriveArray()` using expressions to create the subvariables.

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -18,7 +18,7 @@
 #' @param file character local filename to write to. A default filename will be
 #' generated from the `multitable`'s name if one is not supplied and the
 #' "xlsx" format is requested. Not required for "json" format export.
-#' @param filter a Crunch `filter` object or a vector of names 
+#' @param filter a Crunch `filter` object or a vector of names
 #' of \code{\link{filters}} defined in the dataset.
 #' @param ... Additional "options" passed to the tab book POST request.
 #' More details can be found
@@ -57,7 +57,7 @@ tabBook <- function(multitable, dataset, weight = crunch::weight(dataset),
     if (!is.null(weight)) {
         weight <- self(weight)
     }
-    flt <- filter
+
     if (!is.null(filter) & all(is.character(filter))) {
         filter_name <- filter
         available <- filter_name %in% names(filters(dataset))
@@ -66,15 +66,19 @@ tabBook <- function(multitable, dataset, weight = crunch::weight(dataset),
         }
         filter <- filters(dataset)[filter]
     }
-    if (inherits(filter, "FilterCatalog")) filter <- lapply(urls(filter), function(x) list(filter=x))
-    if (inherits(filter, "CrunchFilter")) filter <- list(list(filter=self(filter)))
+    if (inherits(filter, "FilterCatalog")) filter <- lapply(urls(filter), function(x) {
+        list(filter = x)
+    })
+    if (inherits(filter, "CrunchFilter")) filter <- list(list(filter = self(filter)))
 
     expr_filter <- activeFilter(dataset)
-    if (is.CrunchExpr(expr_filter)) expr_filter <- list(c(zcl(expr_filter), name = formatExpression(expr_filter)))
-    
-    if(length(filter) > 0 && !is.null(expr_filter)){
+    if (is.CrunchExpr(expr_filter)) {
+        expr_filter <- list(c(zcl(expr_filter), name = formatExpression(expr_filter)))
+    }
+
+    if(length(filter) > 0 && !is.null(expr_filter)) {
         filter <- unname(c(filter, expr_filter))
-    } else if (!is.null(expr_filter)){
+    } else if (!is.null(expr_filter)) {
         filter <- expr_filter
     }
 

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -64,7 +64,7 @@ tabBook <- function(multitable, dataset, weight = crunch::weight(dataset),
     }
 
     body <- list(
-        filter = zcl(filter),
+        filter = list(self(filter)),
         weight = weight,
         options = list(...)
     )

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -18,8 +18,8 @@
 #' @param file character local filename to write to. A default filename will be
 #' generated from the `multitable`'s name if one is not supplied and the
 #' "xlsx" format is requested. Not required for "json" format export.
-#' @param filter a [`CrunchFilter`] or a vector of names of filters defined
-#' in the dataset.
+#' @param filter a Crunch `filter` object or a vector of names 
+#' of \code{\link{filters}} defined in the dataset.
 #' @param ... Additional "options" passed to the tab book POST request.
 #' More details can be found
 #' [in the crunch API documentation](

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -20,6 +20,9 @@
 #' generated from the `multitable`'s name if one is not supplied and the
 #' "xlsx" format is requested. Not required for "json" format export.
 #' @param ... Additional "options" passed to the tab book POST request.
+#' More details can be found 
+#' [in the crunch API documentation](
+#' https://docs.crunch.io/endpoint-reference/endpoint-tabbook.html#options)
 #' @param filter [`filter`]s or strings with a filter's name to use in the tab
 #' book. (`NULL` the default uses no filter)
 #' @return If "json" format is requested, the function returns an object of
@@ -59,7 +62,9 @@ tabBook <- function(multitable, dataset, weight = crunch::weight(dataset),
     if (is.character(filter)) {
         filter_name <- filter
         available <- filter_name %in% names(filters(dataset))
-        if (any(!available)) halt("Could not find filter named: ", paste(filter_name[!available], collapse = ", "))
+        if (any(!available)) {
+            halt("Could not find filter named: ", paste(filter_name[!available], collapse = ", "))
+        }
         filter <- filters(dataset)[filter]
     }
 

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -20,7 +20,7 @@
 #' generated from the `multitable`'s name if one is not supplied and the
 #' "xlsx" format is requested. Not required for "json" format export.
 #' @param ... Additional "options" passed to the tab book POST request.
-#' More details can be found 
+#' More details can be found
 #' [in the crunch API documentation](
 #' https://docs.crunch.io/endpoint-reference/endpoint-tabbook.html#options)
 #' @param filter [`filter`]s or strings with a filter's name to use in the tab

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -8,8 +8,9 @@
 #' workbook, you'll get a TabBookResult object, containing nested CrunchCube
 #' results. You can then further format these and construct custom tab reports.
 #' @param multitable a `Multitable` object
-#' @param dataset CrunchDataset, which may have been subsetted with a filter
-#' expression on the rows and a selection of variables on the columns.
+#' @param dataset CrunchDataset, which may have a selection of variables on the
+#' columns (ad-hoc filters are not supported, you must use existing named filter
+#' in the `filter` argument).
 #' @param weight a CrunchVariable that has been designated as a potential
 #' weight variable for `dataset`, or `NULL` for unweighted results.
 #' Default is the currently applied [`weight`].
@@ -20,7 +21,7 @@
 #' "xlsx" format is requested. Not required for "json" format export.
 #' @param ... Additional "options" passed to the tab book POST request.
 #' @param filter A [`filter`] or string with a filter's name to use in the tab
-#' book. `NULL`, the default will use the currently active filter.
+#' book.
 #' @return If "json" format is requested, the function returns an object of
 #' class `TabBookResult`, containing a list of `MultitableResult`
 #' objects, which themselves contain `CrunchCube`s. If "xlsx" is requested,
@@ -31,7 +32,7 @@
 #' @examples
 #' \dontrun{
 #' m <- newMultitable(~ gender + age4 + marstat, data = ds)
-#' tabBook(m, ds[ds$income > 1000000, ], format = "xlsx", file = "wealthy-tab-book.xlsx")
+#' tabBook(m, ds, format = "xlsx", file = "wealthy-tab-book.xlsx", filter = "wealthy")
 #' book <- tabBook(m, ds) # Returns a TabBookResult
 #' tables <- prop.table(book, 2)
 #' }
@@ -55,9 +56,7 @@ tabBook <- function(multitable, dataset, weight = crunch::weight(dataset),
         weight <- self(weight)
     }
 
-    if (is.null(filter)) {
-        filter <- activeFilter(dataset)
-    } else if (is.character(filter)) {
+    if (is.character(filter)) {
         filter_name <- filter
         filter <- filters(dataset)[[filter]]
         if (is.null(filter)) halt("Could not find filter named '", filter_name, "'")

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -19,7 +19,7 @@
 #' generated from the `multitable`'s name if one is not supplied and the
 #' "xlsx" format is requested. Not required for "json" format export.
 #' @param ... Additional "options" passed to the tab book POST request.
-#' @param filter A [`filter`] or string with a filter's name to use in the tab 
+#' @param filter A [`filter`] or string with a filter's name to use in the tab
 #' book. `NULL`, the default will use the currently active filter.
 #' @return If "json" format is requested, the function returns an object of
 #' class `TabBookResult`, containing a list of `MultitableResult`

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -19,6 +19,8 @@
 #' generated from the `multitable`'s name if one is not supplied and the
 #' "xlsx" format is requested. Not required for "json" format export.
 #' @param ... Additional "options" passed to the tab book POST request.
+#' @param filter A [`filter`] or string with a filter's name to use in the tab 
+#' book. `NULL`, the default will use the currently active filter.
 #' @return If "json" format is requested, the function returns an object of
 #' class `TabBookResult`, containing a list of `MultitableResult`
 #' objects, which themselves contain `CrunchCube`s. If "xlsx" is requested,
@@ -36,7 +38,7 @@
 #' @importFrom jsonlite fromJSON
 #' @export
 tabBook <- function(multitable, dataset, weight = crunch::weight(dataset),
-                    format = c("json", "xlsx"), file, ...) {
+                    format = c("json", "xlsx"), file, ..., filter = NULL) {
     f <- match.arg(format)
     accept <- extToContentType(f)
     if (missing(file)) {
@@ -52,8 +54,17 @@ tabBook <- function(multitable, dataset, weight = crunch::weight(dataset),
     if (!is.null(weight)) {
         weight <- self(weight)
     }
+
+    if (is.null(filter)) {
+        filter <- activeFilter(dataset)
+    } else if (is.character(filter)) {
+        filter_name <- filter
+        filter <- filters(dataset)[[filter]]
+        if (is.null(filter)) halt("Could not find filter named '", filter_name, "'")
+    }
+
     body <- list(
-        filter = zcl(activeFilter(dataset)),
+        filter = zcl(filter),
         weight = weight,
         options = list(...)
     )

--- a/man/tabBook.Rd
+++ b/man/tabBook.Rd
@@ -32,7 +32,9 @@ Default is the currently applied \code{\link{weight}}.}
 generated from the \code{multitable}'s name if one is not supplied and the
 "xlsx" format is requested. Not required for "json" format export.}
 
-\item{...}{Additional "options" passed to the tab book POST request.}
+\item{...}{Additional "options" passed to the tab book POST request.
+More details can be found
+\href{https://docs.crunch.io/endpoint-reference/endpoint-tabbook.html#options}{in the crunch API documentation}}
 
 \item{filter}{\code{\link{filter}}s or strings with a filter's name to use in the tab
 book. (\code{NULL} the default uses no filter)}

--- a/man/tabBook.Rd
+++ b/man/tabBook.Rd
@@ -31,8 +31,8 @@ Default is the currently applied \code{\link{weight}}.}
 generated from the \code{multitable}'s name if one is not supplied and the
 "xlsx" format is requested. Not required for "json" format export.}
 
-\item{filter}{a \code{\link{CrunchFilter}} or a vector of names of filters defined
-in the dataset.}
+\item{filter}{a Crunch \code{filter} object or a vector of names
+of \code{\link{filters}} defined in the dataset.}
 
 \item{...}{Additional "options" passed to the tab book POST request.
 More details can be found

--- a/man/tabBook.Rd
+++ b/man/tabBook.Rd
@@ -10,7 +10,8 @@ tabBook(
   weight = crunch::weight(dataset),
   format = c("json", "xlsx"),
   file,
-  ...
+  ...,
+  filter = NULL
 )
 }
 \arguments{
@@ -31,6 +32,9 @@ generated from the \code{multitable}'s name if one is not supplied and the
 "xlsx" format is requested. Not required for "json" format export.}
 
 \item{...}{Additional "options" passed to the tab book POST request.}
+
+\item{filter}{A \code{\link{filter}} or string with a filter's name to use in the tab
+book. \code{NULL}, the default will use the currently active filter.}
 }
 \value{
 If "json" format is requested, the function returns an object of

--- a/man/tabBook.Rd
+++ b/man/tabBook.Rd
@@ -17,8 +17,9 @@ tabBook(
 \arguments{
 \item{multitable}{a \code{Multitable} object}
 
-\item{dataset}{CrunchDataset, which may have been subsetted with a filter
-expression on the rows and a selection of variables on the columns.}
+\item{dataset}{CrunchDataset, which may have a selection of variables on the
+columns (ad-hoc filters are not supported, you must use existing named filter
+in the \code{filter} argument).}
 
 \item{weight}{a CrunchVariable that has been designated as a potential
 weight variable for \code{dataset}, or \code{NULL} for unweighted results.
@@ -34,7 +35,7 @@ generated from the \code{multitable}'s name if one is not supplied and the
 \item{...}{Additional "options" passed to the tab book POST request.}
 
 \item{filter}{A \code{\link{filter}} or string with a filter's name to use in the tab
-book. \code{NULL}, the default will use the currently active filter.}
+book.}
 }
 \value{
 If "json" format is requested, the function returns an object of
@@ -58,7 +59,7 @@ results. You can then further format these and construct custom tab reports.
 \examples{
 \dontrun{
 m <- newMultitable(~ gender + age4 + marstat, data = ds)
-tabBook(m, ds[ds$income > 1000000, ], format = "xlsx", file = "wealthy-tab-book.xlsx")
+tabBook(m, ds, format = "xlsx", file = "wealthy-tab-book.xlsx", filter = "wealthy")
 book <- tabBook(m, ds) # Returns a TabBookResult
 tables <- prop.table(book, 2)
 }

--- a/man/tabBook.Rd
+++ b/man/tabBook.Rd
@@ -34,8 +34,8 @@ generated from the \code{multitable}'s name if one is not supplied and the
 
 \item{...}{Additional "options" passed to the tab book POST request.}
 
-\item{filter}{A \code{\link{filter}} or string with a filter's name to use in the tab
-book.}
+\item{filter}{\code{\link{filter}}s or strings with a filter's name to use in the tab
+book. (\code{NULL} the default uses no filter)}
 }
 \value{
 If "json" format is requested, the function returns an object of

--- a/man/tabBook.Rd
+++ b/man/tabBook.Rd
@@ -10,16 +10,15 @@ tabBook(
   weight = crunch::weight(dataset),
   format = c("json", "xlsx"),
   file,
-  ...,
-  filter = NULL
+  filter = NULL,
+  ...
 )
 }
 \arguments{
 \item{multitable}{a \code{Multitable} object}
 
-\item{dataset}{CrunchDataset, which may have a selection of variables on the
-columns (ad-hoc filters are not supported, you must use existing named filter
-in the \code{filter} argument).}
+\item{dataset}{CrunchDataset, which may be subset with a filter expression
+on the rows, and a selection of variables to use on the columns.}
 
 \item{weight}{a CrunchVariable that has been designated as a potential
 weight variable for \code{dataset}, or \code{NULL} for unweighted results.
@@ -32,12 +31,12 @@ Default is the currently applied \code{\link{weight}}.}
 generated from the \code{multitable}'s name if one is not supplied and the
 "xlsx" format is requested. Not required for "json" format export.}
 
+\item{filter}{a \code{\link{CrunchFilter}} or a vector of names of filters defined
+in the dataset.}
+
 \item{...}{Additional "options" passed to the tab book POST request.
 More details can be found
 \href{https://docs.crunch.io/endpoint-reference/endpoint-tabbook.html#options}{in the crunch API documentation}}
-
-\item{filter}{\code{\link{filter}}s or strings with a filter's name to use in the tab
-book. (\code{NULL} the default uses no filter)}
 }
 \value{
 If "json" format is requested, the function returns an object of

--- a/tests/testthat/test-multitables.R
+++ b/tests/testthat/test-multitables.R
@@ -8,7 +8,16 @@ test_that("default name for formula", {
 with_mock_crunch({
     ds <- loadDataset("test ds") ## Has 2 multitables
     ds2 <- loadDataset("ECON.sav") ## Has no multitables
-
+    with_POST("https://app.crunch.io/api/datasets/1/filters/filter1/", {
+        ## Mock the return of that creation
+        f1 <- newFilter("A filter", ds$gender == "Male", catalog = filters(ds))
+        expect_is(f1, "CrunchFilter")
+    })
+    with_POST("https://app.crunch.io/api/datasets/1/filters/filter2/", {
+        ## Mock the return of that creation
+        f2 <- newFilter("A filter", ds$gender == "Male", catalog = filters(ds))
+        expect_is(f2, "CrunchFilter")
+    })
     test_that("multitables() getter", {
         expect_is(multitables(ds), "MultitableCatalog")
         expect_is(multitables(ds2), "MultitableCatalog")
@@ -271,6 +280,69 @@ with_mock_crunch({
                 "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/"
             ),
             "Accept: application/json"
+        )
+    })
+    filts <- filters(ds)
+    test_that("tabBook with no filter of any kind", {
+        expect_POST(
+            tabBook(mults[[1]], 
+                    data = ds, format = "json")
+            ,
+            "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
+            '{\"filter\":null,\"weight\":null,\"options\":[]}'
+        )
+    })
+    test_that("tabBook filter argument with chr name", {
+        expect_POST(
+            tabBook(mults[[1]], 
+                    filter="Public filter",
+                    data = ds, format = "json")
+            ,
+            "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"}],\"weight\":null,\"options\":[]}'
+        )
+    })
+
+    test_that("tabBook filter argument with filter expression", {
+        expect_POST(
+            tabBook(mults[[1]], 
+                    data = ds[ds$gender == 'Male',], format = "json")
+            ,
+            "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
+            '{\"filter\":[{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}'
+        )
+    })
+
+    test_that("tabBook filter argument with filter object", {
+        expect_POST(
+            tabBook(mults[[1]], 
+                    filter=f1, #mock created at top
+                    data = ds, format = "json")
+            ,
+            "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"}],\"weight\":null,\"options\":[]}'
+        )
+    })
+
+    test_that("tabBook filter argument with two chr filter names", {
+        expect_POST(
+            tabBook(mults[[1]], 
+                    filter=c("Occasional Political Interest", "Public filter"),
+                    data = ds, format = "json")
+            ,
+            "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"},{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"}],\"weight\":null,\"options\":[]}'
+        )
+    })
+
+    test_that("tabBook filter argument with chr and filter expression", {
+        expect_POST(
+            tabBook(mults[[1]], 
+                    filter = "Public filter",
+                    data = ds[ds$gender == 'Male',], format = "json")
+            ,
+            "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"},{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}'
         )
     })
 

--- a/tests/testthat/test-multitables.R
+++ b/tests/testthat/test-multitables.R
@@ -285,7 +285,7 @@ with_mock_crunch({
     filts <- filters(ds)
     test_that("tabBook with no filter of any kind", {
         expect_POST(
-            tabBook(mults[[1]], 
+            tabBook(mults[[1]],
                     data = ds, format = "json")
             ,
             "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
@@ -294,7 +294,7 @@ with_mock_crunch({
     })
     test_that("tabBook filter argument with chr name", {
         expect_POST(
-            tabBook(mults[[1]], 
+            tabBook(mults[[1]],
                     filter="Public filter",
                     data = ds, format = "json")
             ,
@@ -315,7 +315,7 @@ with_mock_crunch({
 
     test_that("tabBook filter argument with filter object", {
         expect_POST(
-            tabBook(mults[[1]], 
+            tabBook(mults[[1]],
                     filter=f1, #mock created at top
                     data = ds, format = "json")
             ,
@@ -326,7 +326,7 @@ with_mock_crunch({
 
     test_that("tabBook filter argument with two chr filter names", {
         expect_POST(
-            tabBook(mults[[1]], 
+            tabBook(mults[[1]],
                     filter=c("Occasional Political Interest", "Public filter"),
                     data = ds, format = "json")
             ,
@@ -337,12 +337,23 @@ with_mock_crunch({
 
     test_that("tabBook filter argument with chr and filter expression", {
         expect_POST(
-            tabBook(mults[[1]], 
+            tabBook(mults[[1]],
                     filter = "Public filter",
                     data = ds[ds$gender == 'Male',], format = "json")
             ,
             "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
             '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"},{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}'
+        )
+    })
+
+    test_that("tabBook filter argument with filter object and filter expression", {
+        expect_POST(
+            tabBook(mults[[1]],
+                    filter = f1,
+                    data = ds[ds$gender == 'Male',], format = "json")
+            ,
+            "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"},{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}'
         )
     })
 

--- a/tests/testthat/test-multitables.R
+++ b/tests/testthat/test-multitables.R
@@ -295,43 +295,43 @@ with_mock_crunch({
     test_that("tabBook filter argument with chr name", {
         expect_POST(
             tabBook(mults[[1]],
-                    filter="Public filter",
+                    filter = "Public filter",
                     data = ds, format = "json")
             ,
             "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
-            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"}],\"weight\":null,\"options\":[]}'
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"}],\"weight\":null,\"options\":[]}' # nolint
         )
     })
 
     test_that("tabBook filter argument with filter expression", {
         expect_POST(
-            tabBook(mults[[1]], 
-                    data = ds[ds$gender == 'Male',], format = "json")
+            tabBook(mults[[1]],
+                    data = ds[ds$gender == "Male",], format = "json")
             ,
             "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
-            '{\"filter\":[{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}'
+            '{\"filter\":[{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}' # nolint
         )
     })
 
     test_that("tabBook filter argument with filter object", {
         expect_POST(
             tabBook(mults[[1]],
-                    filter=f1, #mock created at top
+                    filter = f1, #mock created at top
                     data = ds, format = "json")
             ,
             "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
-            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"}],\"weight\":null,\"options\":[]}'
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"}],\"weight\":null,\"options\":[]}' # nolint
         )
     })
 
     test_that("tabBook filter argument with two chr filter names", {
         expect_POST(
             tabBook(mults[[1]],
-                    filter=c("Occasional Political Interest", "Public filter"),
+                    filter = c("Occasional Political Interest", "Public filter"),
                     data = ds, format = "json")
             ,
             "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
-            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"},{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"}],\"weight\":null,\"options\":[]}'
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"},{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"}],\"weight\":null,\"options\":[]}' # nolint
         )
     })
 
@@ -339,10 +339,10 @@ with_mock_crunch({
         expect_POST(
             tabBook(mults[[1]],
                     filter = "Public filter",
-                    data = ds[ds$gender == 'Male',], format = "json")
+                    data = ds[ds$gender == "Male",], format = "json")
             ,
             "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
-            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"},{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}'
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter2/\"},{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}' # nolint
         )
     })
 
@@ -350,10 +350,10 @@ with_mock_crunch({
         expect_POST(
             tabBook(mults[[1]],
                     filter = f1,
-                    data = ds[ds$gender == 'Male',], format = "json")
+                    data = ds[ds$gender == "Male",], format = "json")
             ,
             "https://app.crunch.io/api/datasets/1/multitables/ed30c4/tabbook/",
-            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"},{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}'
+            '{\"filter\":[{\"filter\":\"https://app.crunch.io/api/datasets/1/filters/filter1/\"},{\"function\":\"==\",\"args\":[{\"variable\":\"https://app.crunch.io/api/datasets/1/variables/gender/\"},{\"value\":1}],\"name\":\"gender == \\\"Male\\\"\"}],\"weight\":null,\"options\":[]}' # nolint
         )
     })
 


### PR DESCRIPTION
Adds ability to set override active filter on tabbook export.

~As I pushed, realized we might want to allow CrunchExpr in the filter argument, worth it?~
No, because CrunchExprs didn't work in old code.
