### PR TITLE
direct assignment of logical expression, fixes #286

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # crunch 1.27.5 (Development version)
+* You can now derive a variable directly from a logical expression (#286)
 
 # crunch 1.27.4
 * Fixes to pkgdown documentation website

--- a/R/dataset-update.R
+++ b/R/dataset-update.R
@@ -75,14 +75,6 @@ setMethod(
 #' @rdname crunch-extract
 #' @export
 setMethod(
-    "[[<-", c("CrunchDataset", "character", "missing", "CrunchLogicalExpr"),
-    function(x, i, value) {
-        halt("Cannot currently derive a logical variable")
-    }
-)
-#' @rdname crunch-extract
-#' @export
-setMethod(
     "[[<-", c("CrunchDataset", "ANY"),
     function(x, i, value) {
         halt("Only character (name) indexing supported for [[<-")

--- a/man/crunch-extract.Rd
+++ b/man/crunch-extract.Rd
@@ -46,7 +46,6 @@
 \alias{[[<-,CrunchDataset,character,missing,CrunchVariable-method}
 \alias{[[<-,CrunchDataset,ANY,missing,CrunchVariable-method}
 \alias{[[<-,CrunchDataset,character,missing,ANY-method}
-\alias{[[<-,CrunchDataset,character,missing,CrunchLogicalExpr-method}
 \alias{[[<-,CrunchDataset,ANY,ANY,ANY-method}
 \alias{[[<-,CrunchDataset,character,missing,NULL-method}
 \alias{[[<-,CrunchDataset,ANY,missing,NULL-method}
@@ -260,8 +259,6 @@
 \S4method{[[}{CrunchDataset,ANY,missing,CrunchVariable}(x, i) <- value
 
 \S4method{[[}{CrunchDataset,character,missing,ANY}(x, i) <- value
-
-\S4method{[[}{CrunchDataset,character,missing,CrunchLogicalExpr}(x, i) <- value
 
 \S4method{[[}{CrunchDataset,ANY,ANY,ANY}(x, i) <- value
 

--- a/tests/testthat/test-derive.R
+++ b/tests/testthat/test-derive.R
@@ -74,10 +74,13 @@ with_mock_crunch({
         )
     })
 
-    test_that("What happens when you try to derive a logical", {
-        expect_error(
+    test_that("derive from logical expression issues correct POST", {
+        expect_POST(
             ds$kids <- ds$birthyr > 2000,
-            "Cannot currently derive a logical variable"
+            "https://app.crunch.io/api/datasets/1/variables/",
+            '{"derivation":{"function":">","args":[{"variable":',
+            '"https://app.crunch.io/api/datasets/1/variables/birthyr/"},',
+            '{"value":2000}]},"name":"kids","alias":"kids"}'
         )
     })
 })
@@ -105,6 +108,14 @@ with_test_authentication({
 
     test_that("derivation returns NULL if the variable is not derived", {
         expect_null(derivation(ds$v3))
+    })
+
+    ds$v3l <- ds$v3 > 10
+    test_that("can derive a logical expression", {
+        expect_true(is.derived(ds$v3l))
+        expect_true(is.Categorical(ds$v3l))
+        expect_prints(derivation(ds$v3l), "Crunch expression: v3 > 10")
+        expect_equivalent(as.vector(ds$v3l), df$v3 > 10)
     })
 
     test_that("derivation()<- can change a derived variable", {


### PR DESCRIPTION
Was explicitly forbidden before, but the API must have been updated so that it works:

Can now do something like:
```
ds$z <- ds$y == "a"
```