### PR TITLE
fix regex for progress removal in http redaction

### DIFF
--- a/inst/httptest/redact.R
+++ b/inst/httptest/redact.R
@@ -10,7 +10,7 @@ function(response) {
         redact_auth() %>%
         gsub_response("([0-9a-f]{6})[0-9a-f]{26}", "\\1") %>% ## Prune UUIDs
         gsub_response(
-            "https.//app.crunch.io/api/progress/.*?/",
+            "https.//app.crunch.io/api/progress/[^\"].*?/",
             "https://app.crunch.io/api/progress/"
         )
 }

--- a/inst/httptest/start-vignette.R
+++ b/inst/httptest/start-vignette.R
@@ -18,7 +18,7 @@ set_redactor(function(response) {
         redact_auth() %>%
         gsub_response("([0-9a-f]{6})[0-9a-f]{26}", "\\1") %>% ## Prune UUIDs
         gsub_response(
-            "https.//app.crunch.io/api/progress/.*?/",
+            "https.//app.crunch.io/api/progress/[^\"].*?/",
             "https://app.crunch.io/api/progress/"
         ) %>% ## Progress is meaningless in mocks
         gsub_response("https.//app.crunch.io", "") %>% ## Shorten URL


### PR DESCRIPTION
This fix exists on at least one branch already, but I want to push it into master so Brandon can use it when making mocks for cruntabs.

The old regex has problems because there is a "progress" item in the views now, and so what originally looks like this:
```
"progress": "https://app.crunch.io/api/progress/",
"search": "https://app.crunch.io/api/search/",
```

with the old regex gets converted to:
```
"progress": "https://app.crunch.io/api/progress//app.crunch.io/api/search/",
```
