### PR TITLE
[WIP] Add derived subvar

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -157,7 +157,7 @@ setGeneric("type<-", function(x, value) standardGeneric("type<-"))
 
 setGeneric("hide", function(x) standardGeneric("hide"))
 setGeneric("unhide", function(x) standardGeneric("unhide"))
-setGeneric("derivation", function(x) standardGeneric("derivation"))
+setGeneric("derivation", function(x, ...) standardGeneric("derivation"))
 setGeneric("derivation<-", function(x, value) standardGeneric("derivation<-"))
 
 

--- a/R/variable-derivation.R
+++ b/R/variable-derivation.R
@@ -12,6 +12,7 @@
 #' two variables.
 #'
 #' @param x a variable
+#' @param absoluteURLs Whether to convert variable URLs to absolute URLs (defaults to TRUE)
 #' @param value a `CrunchExpr` to be used as the derivation (for the setter
 #' only) or `NULL` to integrate a derived variable. For `is.derived`, `FALSE`
 #' can be used to integrate a derived variable.
@@ -48,7 +49,7 @@ NULL
 
 #' @export
 #' @rdname derivations
-setMethod("derivation", "CrunchVariable", function(x) {
+setMethod("derivation", "CrunchVariable", function(x, absoluteURLs = TRUE) {
     if (!is.derived(x)) {
         return(NULL)
     }
@@ -56,7 +57,7 @@ setMethod("derivation", "CrunchVariable", function(x) {
     # self(x) is needed and not variableCatalog because the variables are stored
     # as '../varid/' and when absoluteURL concats them, the varid from self(x)
     # is automatically removed.
-    expr@expression <- absolutifyVariables(expr@expression, self(x))
+    if (absoluteURLs) expr@expression <- absolutifyVariables(expr@expression, self(x))
 
     return(expr)
 })

--- a/man/derivations.Rd
+++ b/man/derivations.Rd
@@ -13,7 +13,7 @@
 \alias{is.derived<-}
 \title{Get or set a derived variable's expression}
 \usage{
-\S4method{derivation}{CrunchVariable}(x)
+\S4method{derivation}{CrunchVariable}(x, abosluteURLs = TRUE)
 
 \S4method{derivation}{CrunchVariable,ANY}(x) <- value
 
@@ -29,6 +29,8 @@
 \item{value}{a \code{CrunchExpr} to be used as the derivation (for the setter
 only) or \code{NULL} to integrate a derived variable. For \code{is.derived}, \code{FALSE}
 can be used to integrate a derived variable.}
+
+\item{absoluteURLs}{Whether to convert variable URLs to absolute URLs (defaults to TRUE)}
 }
 \value{
 a \code{CrunchExpr} of the derivation for \code{derivation}; a logical for


### PR DESCRIPTION
Definitely not ready for primetime yet, but wanted to get some notes down.

Weird things:
- `absolutifyVariables` (which modifies the derivation expression before user sees it) is wrong in some cases, likely having to do with array variables. It seems to assume that the variable is given by relative URL, but within `map` zcl function, variables are given by ID only. I have gotten around this by not converting to absolute paths, but I'd like to actually fix.
- For subvariables that are created when the array is first derived, they get their metadata automatically filled in, but we don't get that when adding new ones via derivation. Is it possible to get this? Or a limitation of the API?
- Haven't gotten the MRs to work yet because they have an extra layer of nesting in zcl. Need a better way to do the derivation modification that fails more gracefully and is flexible for at least these 2 cases.

```r
library(crunch)
set.seed(2020-05-18)

levels <- c("Good", "Okay", "Bad")
data <- data.frame(
    x1 = factor(sample(c(levels, NA), 10, TRUE), levels),
    x2 = factor(sample(c(levels, NA), 10, TRUE), levels),
    x3 = factor(sample(c(levels, NA), 10, TRUE), levels)
)

ds <- newDataset(data, name = "combine into array test")
ds$xcat <- deriveArray(ds[1:2], name = "x cat")
ds$xmr <- deriveArray(ds[1:2], name = "x mr", selections = "Good")


# Works in POC
ds$xcat <- addSubvariable(ds$xcat, ds["x3"])

# Does not yet work 
ds$xmr <- addSubvariable(ds$xmr, ds["x3"])
```