### PR TITLE
Keyring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       - _R_CHECK_TESTS_NLINES_=0
     apt_packages:
        - libsodium-dev
+    before_script:
+       - Rscript -e 'devtools::install_github("rstudio/rmarkdown")'
   - os: linux
     r: oldrel
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
     env:
       - _R_CHECK_LENGTH_1_LOGIC2_=true
       - _R_CHECK_TESTS_NLINES_=0
+    apt_packages:
+       - libsodium-dev
     before_script:
        - Rscript -e 'devtools::install_github("rstudio/rmarkdown")'
   - os: linux
@@ -19,12 +21,16 @@ matrix:
     env:
       - _R_CHECK_LENGTH_1_LOGIC2_=true
       - _R_CHECK_TESTS_NLINES_=0
+    apt_packages:
+       - libsodium-dev
   - os: linux
     r: release
     env:
       - _R_CHECK_LENGTH_1_LOGIC2_=true
       - _R_CHECK_TESTS_NLINES_=0
       - secure: "BWvMPmOiTzFNfFz3Ok+WHk6FjNNjK8qV5QohBhS0bgsMgeCrx4Zu3IXp42cXaEzzCe/VEnnEyYYTkZROS3mdLRAlOHnEHvCJMtETOODOK6EFGUFDv+C7AXZyqbdoNPrGrW5QKppHAVbTuL/A9z+tnBaeyG68GhOmOFBk4mciHNc="
+    apt_packages:
+       - libsodium-dev
     after_success:
       - Rscript -e 'covr::codecov()'
       - R CMD INSTALL $PKG_TARBALL
@@ -36,6 +42,8 @@ matrix:
     env:
       - _R_CHECK_LENGTH_1_LOGIC2_=true
       - _R_CHECK_TESTS_NLINES_=0
+    apt_packages:
+       - libsodium-dev
   - os: windows
     language: shell
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
     env:
       - _R_CHECK_LENGTH_1_LOGIC2_=true
       - _R_CHECK_TESTS_NLINES_=0
-    apt_packages:
-       - libsodium-dev
     before_script:
        - Rscript -e 'devtools::install_github("rstudio/rmarkdown")'
   - os: linux
@@ -21,16 +19,12 @@ matrix:
     env:
       - _R_CHECK_LENGTH_1_LOGIC2_=true
       - _R_CHECK_TESTS_NLINES_=0
-    apt_packages:
-       - libsodium-dev
   - os: linux
     r: release
     env:
       - _R_CHECK_LENGTH_1_LOGIC2_=true
       - _R_CHECK_TESTS_NLINES_=0
       - secure: "BWvMPmOiTzFNfFz3Ok+WHk6FjNNjK8qV5QohBhS0bgsMgeCrx4Zu3IXp42cXaEzzCe/VEnnEyYYTkZROS3mdLRAlOHnEHvCJMtETOODOK6EFGUFDv+C7AXZyqbdoNPrGrW5QKppHAVbTuL/A9z+tnBaeyG68GhOmOFBk4mciHNc="
-    apt_packages:
-       - libsodium-dev
     after_success:
       - Rscript -e 'covr::codecov()'
       - R CMD INSTALL $PKG_TARBALL

--- a/R/auth.R
+++ b/R/auth.R
@@ -91,7 +91,6 @@ get_user_pass_combo <- function(email, password) {
         } else if (n.passes == 1 & keyring::key_list("crunch")$username[1] == "") {
           password <- keyring::key_get("crunch")
         } else if (interactive() == TRUE) {
-          #NB - not sure if we want this warning message - could be helpful or spammy
           warning("Saved Crunch passwords in keyring do not match specified email")
         }
       }

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -83,7 +83,6 @@ test_that("Match username and password with no saved password", {
 test_that("Match username and password, with single saved keyring password", {
 
   #Single Keyring password, username specified via login, saved password matches specified username
-  keyring::key_set_with_value("crunch", username = "test@crunch.io", password = "abc123")
   with_mock_auth_settings(
     opt_crunch_email = "test@crunch.io",
     opt_crunch_pw = "abc123",

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -97,12 +97,11 @@ test_that("Match username and password, with single saved keyring password", {
   with_mock_auth_settings(
     keyring_users = "test@crunch.io",
     keyring_pws = "abc123",
-    expect_warning(
-      expect_identical(
-        get_user_pass_combo(email = "test@yougov.com", password = NULL),
-        list(email = "test@yougov.com", password = NULL)
+    expect_identical(
+      suppressWarnings(
+        get_user_pass_combo(email = "test@yougov.com", password = NULL)
       ),
-      "Saved Crunch passwords in keyring do not match specified email"
+      list(email = "test@yougov.com", password = NULL)
     )
   )
 
@@ -134,12 +133,11 @@ test_that("Match username and password, with single saved keyring password", {
     keyring_users = "test@crunch.io",
     keyring_pws = "abc123",
     env_r_crunch_email = "test@yougov.com",
-    expect_warning(
-      expect_identical(
-        get_user_pass_combo(email = NULL, password = NULL),
-        list(email = "test@yougov.com", password = NULL)
+    expect_identical(
+      suppressWarnings(
+        get_user_pass_combo(email = NULL, password = NULL)
       ),
-      "Saved Crunch passwords in keyring do not match specified email"
+      list(email = "test@yougov.com", password = NULL)
     )
   )
 
@@ -181,12 +179,11 @@ test_that("Match username and password, with multiple saved keyring passwords", 
   with_mock_auth_settings(
     keyring_users = c("user@gmail.com", "test@crunch.io"),
     keyring_pws = c("foobar", "abc123"),
-    expect_warning(
-      expect_identical(
-        get_user_pass_combo(email = "test@yougov.com", password = NULL),
-        list(email = "test@yougov.com", password = NULL)
+    expect_identical(
+      suppressWarnings(
+        get_user_pass_combo(email = "test@yougov.com", password = NULL)
       ),
-      "Saved Crunch passwords in keyring do not match specified email"
+      list(email = "test@yougov.com", password = NULL)
     )
   )
 
@@ -219,12 +216,11 @@ test_that("Match username and password, with multiple saved keyring passwords", 
     keyring_users = c("user@gmail.com", "test@crunch.io"),
     keyring_pws = c("foobar", "abc123"),
     env_r_crunch_email = "test@yougov.com",
-    expect_warning(
-      expect_identical(
-        get_user_pass_combo(email = NULL, password = NULL),
-        list(email = "test@yougov.com", password = NULL)
+    expect_identical(
+      suppressWarnings(
+        get_user_pass_combo(email = NULL, password = NULL)
       ),
-      "Saved Crunch passwords in keyring do not match specified email"
+      list(email = "test@yougov.com", password = NULL)
     )
   )
 })

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -38,7 +38,7 @@ with_mock_auth_settings <- function(
         `keyring::key_list` = function(service = NULL, keyring = NULL) {
           if (is.null(keyring_users) & is.null(keyring_pws)) {
             data.frame(service = character(0), username = character(0), stringsAsFactors = FALSE)
-          } else if(is.null(keyring_users)){
+          } else if(is.null(keyring_users)) {
             data.frame(service = service, username = "", stringsAsFactors = FALSE)
           } else {
             data.frame(service = service, username = keyring_users, stringsAsFactors = FALSE)


### PR DESCRIPTION
Completed tests. Also made minor changes to `with_mock_auth_settings` functions: making sure the fake `key_list` function mirrored the behaviour of the real function, and making sure the `test_with` command ran correctly.

Worth noting an ssue around CI on Linux/Secret Service that I found mentioned in the [Keyring developer notes](https://github.com/r-lib/keyring/blob/master/inst/development-notes.md#testing-the-package). I'm hoping that this wasn't the root of the initial problem, although I think some of the Windows tests also had issues:

> libsecret uses libglib, and libglib does not allow unloading the package. More precisely, if you unload the keyring package on Linux, then some libglib threads will stay around. If you then reload the package, R will crash.
> 
> This limitation is especially annoying for development with devtools, because devtools::load_all(), devtools::test(), etc. try to unload and reload the package, which results in crashes. A workaround is to run the tests from the command line:
> 
> R -e 'devtools::test()'
> 

We should be aware that the mock test won't catch any change to the data format returned by `key_get`. It seems exceptionally unlikely that the RStudio team would intentionally change this. However, it is conceivable that future OS updates might change how password storage is handled, in a way that requires keyring to make changes.