### PR TITLE
filter escape hatch

### DIFF
--- a/R/slides.R
+++ b/R/slides.R
@@ -561,7 +561,7 @@ setMethod("filter", "ANY", function(x, ...) {
             return(func(x, ...))
         }
     }
-    halt("No method found for filter for object of type ", dQuote(methods::getClass(x)))
+    halt("No method found for filter for object of type ", dQuote(methods::getClass(x))) # nocov
 })
 
 #' @rdname analysis-methods

--- a/R/slides.R
+++ b/R/slides.R
@@ -11,6 +11,7 @@
 #'
 #' @param x a `CrunchSlide`, `AnalysisCatalog`, or `Analysis`
 #' @param value for the setter, a query
+#' @param ... ignored
 #'
 #' @return an `AnalysisCatalog`, `Analysis`, `Cube`, or `Filter`
 #' @rdname analysis-methods

--- a/R/slides.R
+++ b/R/slides.R
@@ -561,7 +561,7 @@ setMethod("filter", "ANY", function(x, ...) {
             return(func(x, ...))
         }
     }
-    halt("No method found for filter for object of type ", dQuote(getClass(x)))
+    halt("No method found for filter for object of type ", dQuote(methods::getClass(x)))
 })
 
 #' @rdname analysis-methods

--- a/R/slides.R
+++ b/R/slides.R
@@ -560,7 +560,7 @@ setMethod("filter", "ANY", function(x, ...) {
     } else {
         func <- stats::filter
     }
-    func(.data = x, ...)
+    func(x, ...)
 })
 
 #' @rdname analysis-methods

--- a/R/slides.R
+++ b/R/slides.R
@@ -555,12 +555,13 @@ setMethod("filter", "Analysis", function(x, ...) {
 #' @rdname analysis-methods
 #' @export
 setMethod("filter", "ANY", function(x, ...) {
-    if ("dplyr" %in% .packages()) {
-        func <- get("filter", asNamespace("dplyr"))
-    } else {
-        func <- stats::filter
+    for (searchpath in search()) {
+        func <- get("filter", as.environment(searchpath))
+        if (!identical(func, crunch::filter)) {
+            return(func(x, ...))
+        }
     }
-    func(x, ...)
+    halt("No method found for filter for object of type ", dQuote(getClass(x)))
 })
 
 #' @rdname analysis-methods

--- a/R/slides.R
+++ b/R/slides.R
@@ -43,7 +43,7 @@ setGeneric("cube", function(x) standardGeneric("cube"))
 setGeneric("cubes", function(x) standardGeneric("cubes"))
 #' @rdname analysis-methods
 #' @export
-setGeneric("filter", function(x, value) standardGeneric("filter"))
+setGeneric("filter", function(x, ...) standardGeneric("filter"))
 #' @rdname analysis-methods
 #' @export
 setGeneric("filter<-", function(x, value) standardGeneric("filter<-"))
@@ -350,7 +350,7 @@ setMethod("analysis<-", c("CrunchSlide", "Analysis"), function(x, value) {
 
 #' @rdname analysis-methods
 #' @export
-setMethod("filter", "CrunchSlide", function(x) {
+setMethod("filter", "CrunchSlide", function(x, ...) {
     analysis <- analyses(x)[[1]]
     return(filter(analysis))
 })
@@ -537,7 +537,7 @@ wrapDisplaySettings <- function(settings) {
 
 #' @rdname analysis-methods
 #' @export
-setMethod("filter", "Analysis", function(x) {
+setMethod("filter", "Analysis", function(x, ...) {
     filt <- x@body$query_environment$filter
     if (length(filt) == 0) {
         return(NULL)
@@ -549,6 +549,17 @@ setMethod("filter", "Analysis", function(x) {
         adhoc_expr <- CrunchExpr(expression = fixAdhocFilterExpression(filt[[1]]))
         return(adhoc_expr)
     }
+})
+
+#' @rdname analysis-methods
+#' @export
+setMethod("filter", "ANY", function(x, ...) {
+    if ("dplyr" %in% .packages()) {
+        func <- get("filter", asNamespace("dplyr"))
+    } else {
+        func <- stats::filter
+    }
+    func(.data = x, ...)
 })
 
 #' @rdname analysis-methods

--- a/man/analysis-methods.Rd
+++ b/man/analysis-methods.Rd
@@ -22,6 +22,7 @@
 \alias{query<-,Analysis,formula-method}
 \alias{cube,Analysis-method}
 \alias{filter,Analysis-method}
+\alias{filter,ANY-method}
 \alias{filter<-,Analysis,CrunchLogicalExpr-method}
 \alias{filter<-,Analysis,CrunchFilter-method}
 \alias{filter<-,Analysis,NULL-method}
@@ -39,7 +40,7 @@ cube(x)
 
 cubes(x)
 
-filter(x, value)
+filter(x, ...)
 
 filter(x) <- value
 
@@ -51,7 +52,7 @@ filter(x) <- value
 
 \S4method{analysis}{CrunchSlide,Analysis}(x) <- value
 
-\S4method{filter}{CrunchSlide}(x)
+\S4method{filter}{CrunchSlide}(x, ...)
 
 \S4method{filter}{CrunchSlide,ANY}(x) <- value
 
@@ -67,7 +68,9 @@ filter(x) <- value
 
 \S4method{cube}{Analysis}(x)
 
-\S4method{filter}{Analysis}(x)
+\S4method{filter}{Analysis}(x, ...)
+
+\S4method{filter}{ANY}(x, ...)
 
 \S4method{filter}{CrunchSlide,ANY}(x) <- value
 

--- a/man/analysis-methods.Rd
+++ b/man/analysis-methods.Rd
@@ -84,6 +84,8 @@ filter(x) <- value
 \item{x}{a \code{CrunchSlide}, \code{AnalysisCatalog}, or \code{Analysis}}
 
 \item{value}{for the setter, a query}
+
+\item{...}{ignored}
 }
 \value{
 an \code{AnalysisCatalog}, \code{Analysis}, \code{Cube}, or \code{Filter}

--- a/tests/testthat/test-decks.R
+++ b/tests/testthat/test-decks.R
@@ -726,6 +726,13 @@ with_mock_crunch({
     })
 })
 
+test_that("filter gets pass through method on non-crunch objects", {
+    expect_equal(
+        crunch::filter(1:100, rep(1, 3)),
+        stats::filter(1:100, rep(1, 3))
+    )
+})
+
 with_test_authentication({
     ds <- newDataset(df)
     test_that("decks can be created", {


### PR DESCRIPTION
When crunch doesn't define a method for filter, filter goes to next filter on namespace and tries that.


``` r
suppressPackageStartupMessages(library(crunch))
identical(filter(1:100, rep(1, 3)), stats::filter(1:100, rep(1, 3)))
#> [1] TRUE
```

``` r
suppressPackageStartupMessages(library(dplyr))
suppressPackageStartupMessages(library(crunch))
identical(filter(mtcars, cyl == 4), dplyr::filter(mtcars, cyl == 4))
#> [1] TRUE
```
