### PR TITLE
fix login message

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -50,7 +50,7 @@ login <- function(email = NULL,
         prompt = paste("[crunch]", getOption("prompt")),
         crunch.old.prompt = getOption("prompt")
     )
-    message("Logged into crunch.io as ", email)
+    message("Logged into crunch.io as ", login_info$email)
     ## Return a Session object
     invisible(session())
 }


### PR DESCRIPTION
missed in #461 - would lead to messages like `Logged into crunch.io as` that were missing the email address