### PR TITLE
fix: branch build for numeric arrays

### DIFF
--- a/tests/testthat/test-make-array.R
+++ b/tests/testthat/test-make-array.R
@@ -252,6 +252,15 @@ with_test_authentication({
 
     whereas("Testing dichotomizing and undichotomizing", {
         ds <- newDataset(mrdf)
+
+        # Explicitly cast mr_1, mr_2 and mr_3 to categorical, before binding.
+        # This is needed because we support both categorical and numerical arrays,
+        # and leaving the constituent variables as numeric would result in
+        # creating a numeric array.
+        cast.these <- grep("mr_", names(ds))
+        ds[cast.these] <- lapply(ds[cast.these], castVariable, "categorical")
+
+        # Now proceed to creating a categorical array from categorical variables.
         ds$arrayVar <- makeArray(ds[c("mr_1", "mr_2", "mr_3")], name = "arrayVar")
         var <- ds$arrayVar
         test_that("setup to make MultipleResponse from CategoricalArray", {


### PR DESCRIPTION
* When creating arrays (by binding) from already exisging variables, we
  used to rely on the fact that we _only_ have categorical arrays. This
  has now changed, and if we create an array from numerical variables,
  it will result in a numerical array. Therefore, if we want to create a
  categorical array, we have to manually cast the constituent variables
  to be of type "categorical", prior to creating the array.