### PR TITLE
Fix for integration test failure reporting

### DIFF
--- a/inst/crunch-test.R
+++ b/inst/crunch-test.R
@@ -151,13 +151,8 @@ with_test_authentication <- function(expr) {
             with_trace("locationHeader", exit = tracer, where = crGET, expr = {
                 ## Wrap this so that we can generate a test failure if
                 ## there's an error rather than just halt the process
-                tryCatch(eval(expr, envir = env),
-                    error = function(e) {
-                        test_that("There are no test code errors", {
-                            expect_error(stop(e$message), NA)
-                        })
-                    }
-                )
+                ## (eg make sure we run the test teardown)
+                eval(expr, envir = env)
             })
         })
     }


### PR DESCRIPTION
Small fix I discovered on the numeric array work to have lines reported during integration test failures. I can't say I totally understand why this works, but am pretty confident that it both gives the correct line number and does the fixture cleanup that the original code was trying to make happen.

Before:
```
══ Failed ══════════════════════════════════════════════════════════════════════════════════════════════════════════════
── 1. Failure (???): There are no test code errors ─────────────────────────────────────────────────────────────────────
`stop(e$message)` threw an error.
Message: something broke
Class:   simpleError/error/condition
Backtrace:
1. testthat::expect_error(stop(e$message), NA)
2. testthat:::quasi_capture(...)
5. rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))

══ DONE ════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Total teardown: Time difference of 0.5233641 secs
user  system elapsed 
3.255   0.256  10.562 
```

After (Note line number in title and in backtrace, and teardown still completes):
```
══ Failed ════════════════════════════════════════════════════════════════════════════════════════════════════════════════
── 1. Error (test-aaa-setup.R:40:1): (code run outside of `test_that()`) ─────────────────────────────────────────────────
Error: something broke
Backtrace:
1. crunch:::with_test_authentication(...) test-aaa-setup.R:40:0
6. httptest::with_trace(...)
7. base::eval.parent(expr)
8. [ base::eval(...) ] with 1 more call

══ DONE ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Total teardown: Time difference of 0.5133069 secs
user  system elapsed 
3.237   0.271  10.004 
```