### PR TITLE
Array cleanup

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -131,10 +131,14 @@ TextVariable <- setClass("TextVariable", contains = "CrunchVariable")
 #' @export DatetimeVariable
 DatetimeVariable <- setClass("DatetimeVariable", contains = "CrunchVariable")
 
+ArrayVariable <- setClass("ArrayVariable",
+    representation("VIRTUAL"), contains = "CrunchVariable"
+)
+
 #' @rdname CrunchVariable
 #' @export CategoricalArrayVariable
 CategoricalArrayVariable <- setClass("CategoricalArrayVariable",
-    contains = "CrunchVariable"
+    contains = "ArrayVariable"
 )
 
 #' @rdname CrunchVariable

--- a/R/show.R
+++ b/R/show.R
@@ -157,10 +157,10 @@ showArrayVariable <- function(x) {
 }
 
 showSubvariables <- function(x) {
-    c("Subvariables:", format_subvar_aliases_and_names(aliases(x), names(x)))
+    c("Subvariables:", format_subvars(aliases(x), names(x)))
 }
 
-format_subvar_aliases_and_names <- function(aliases, names) {
+format_subvars <- function(aliases, names) {
     # Add ticks to aliases
     aliases <- ifelse(grepl("[[:blank:]]", aliases), paste0("`", aliases, "`"), aliases)
     # Make them constant width

--- a/R/show.R
+++ b/R/show.R
@@ -152,13 +152,14 @@ describeDatasetVariables <- function(dataset) {
     }, character(1)))
 }
 
-showCategoricalArrayVariable <- function(x) {
+showArrayVariable <- function(x) {
     c(showCrunchVariableTitle(x), showSubvariables(subvariables(x)))
 }
 
 showSubvariables <- function(x) {
     out <- c("Subvariables:", vapply(index(x), function(s) {
-        paste0("  $`", s$name, "`")
+        alias <- ifelse(grepl("[[:blank:]]", s$alias), paste0("`", s$alias, "`"), s$alias)
+        paste0("  $", alias, " (", s$name, ")")
     }, character(1), USE.NAMES = FALSE))
     return(out)
 }
@@ -405,8 +406,8 @@ setMethod("getShowContent", "Heading", showSubtotalHeading)
 setMethod("getShowContent", "SummaryStat", showSubtotalHeading)
 setMethod("getShowContent", "CrunchVariable", showCrunchVariable)
 setMethod(
-    "getShowContent", "CategoricalArrayVariable",
-    showCategoricalArrayVariable
+    "getShowContent", "ArrayVariable",
+    showArrayVariable
 )
 setMethod("getShowContent", "CrunchDataset", showCrunchDataset)
 setMethod("getShowContent", "Subvariables", showSubvariables)

--- a/R/show.R
+++ b/R/show.R
@@ -157,11 +157,21 @@ showArrayVariable <- function(x) {
 }
 
 showSubvariables <- function(x) {
-    out <- c("Subvariables:", vapply(index(x), function(s) {
-        alias <- ifelse(grepl("[[:blank:]]", s$alias), paste0("`", s$alias, "`"), s$alias)
-        paste0("  $", alias, " (", s$name, ")")
-    }, character(1), USE.NAMES = FALSE))
-    return(out)
+    c("Subvariables:", format_subvar_aliases_and_names(aliases(x), names(x)))
+}
+
+format_subvar_aliases_and_names <- function(aliases, names) {
+    # Add ticks to aliases
+    aliases <- ifelse(grepl("[[:blank:]]", aliases), paste0("`", aliases, "`"), aliases)
+    # Make them constant width
+    aliases <- format(aliases, max(nchar(aliases)))
+
+    # Trim names to remaining width (3 for "  $" before alias, 4 for "  | " after)
+    names_width <- getOption("width", 100) - (3 + nchar(aliases[1]) + 4)
+    needs_trim <- nchar(names) > names_width
+    names[needs_trim] <- paste0(strtrim(names[needs_trim], names_width - 3), "...")
+
+    paste0("  $", aliases, "  | ", names)
 }
 
 showShojiOrder <- function(x, catalog_url = x@catalog_url, key = "name") {

--- a/R/subvariables.R
+++ b/R/subvariables.R
@@ -37,7 +37,7 @@ setGeneric(
 
 #' @rdname Subvariables
 #' @export
-setMethod("subvariables", "CategoricalArrayVariable", function(x) {
+setMethod("subvariables", "ArrayVariable", function(x) {
     # TODO: it may be simpler and cleaner to just get the subvars from the
     # entity rather than the subvariables catalog.
     tup <- tuple(x)
@@ -75,7 +75,7 @@ setMethod("subvariables", "VariableTuple", function(x) {
 #' @rdname Subvariables
 #' @export
 setMethod(
-    "subvariables<-", c("CategoricalArrayVariable", "ANY"),
+    "subvariables<-", c("ArrayVariable", "ANY"),
     function(x, value) {
         halt("Can only assign an object of class Subvariables")
     }
@@ -83,7 +83,7 @@ setMethod(
 #' @rdname Subvariables
 #' @export
 setMethod(
-    "subvariables<-", c("CategoricalArrayVariable", "Subvariables"),
+    "subvariables<-", c("ArrayVariable", "Subvariables"),
     function(x, value) {
         old <- subvariableURLs(tuple(x))
         new <- urls(value)
@@ -220,7 +220,7 @@ as.list.Subvariables <- function(x, ...) lapply(names(x), function(i) x[[i]])
 
 #' @rdname describe-catalog
 #' @export
-setMethod("names", "CategoricalArrayVariable", function(x) {
+setMethod("names", "ArrayVariable", function(x) {
     getIndexSlot(subvariables(x), namekey(x))
 })
 
@@ -231,7 +231,7 @@ setMethod("names", "CategoricalArrayVariable", function(x) {
 
 #' @rdname crunch-extract
 #' @export
-setMethod("[", c("CategoricalArrayVariable", "character"), function(x, i, ...) {
+setMethod("[", c("ArrayVariable", "character"), function(x, i, ...) {
     w <- match(i, names(x)) ## TODO: use whichNameOrURL
     if (any(is.na(w))) {
         halt("Undefined subvariables selected: ", serialPaste(i[is.na(w)]))
@@ -240,13 +240,13 @@ setMethod("[", c("CategoricalArrayVariable", "character"), function(x, i, ...) {
 })
 #' @rdname crunch-extract
 #' @export
-setMethod("[", c("CategoricalArrayVariable", "missing", "ANY"), function(x, i, j, ...) {
+setMethod("[", c("ArrayVariable", "missing", "ANY"), function(x, i, j, ...) {
     return(subvariables(x)[j, ...])
 })
 #' @rdname crunch-extract
 #' @export
 setMethod(
-    "[", c("CategoricalArrayVariable", "missing", "character"),
+    "[", c("ArrayVariable", "missing", "character"),
     function(x, i, j, ...) {
         return(x[j])
     }
@@ -254,12 +254,12 @@ setMethod(
 
 #' @rdname crunch-extract
 #' @export
-setMethod("[[", c("CategoricalArrayVariable", "ANY"), function(x, i, ...) {
+setMethod("[[", c("ArrayVariable", "ANY"), function(x, i, ...) {
     return(subvariables(x)[[i, ...]])
 })
 #' @rdname crunch-extract
 #' @export
-setMethod("[[", c("CategoricalArrayVariable", "character"), function(x, i, ...) {
+setMethod("[[", c("ArrayVariable", "character"), function(x, i, ...) {
     i <- match(i, names(x))
     if (is.na(i)) {
         return(NULL)
@@ -269,13 +269,13 @@ setMethod("[[", c("CategoricalArrayVariable", "character"), function(x, i, ...) 
 
 #' @rdname crunch-extract
 #' @export
-setMethod("$", "CategoricalArrayVariable", function(x, name) x[[name]])
+setMethod("$", "ArrayVariable", function(x, name) x[[name]])
 
 
 #' @rdname crunch-extract
 #' @export
 setMethod(
-    "[[<-", c("CategoricalArrayVariable", "ANY", "missing", "ANY"),
+    "[[<-", c("ArrayVariable", "ANY", "missing", "ANY"),
     function(x, i, value) {
         subvariables(x)[[i]] <- value
         return(x)
@@ -284,7 +284,7 @@ setMethod(
 #' @rdname crunch-extract
 #' @export
 setMethod(
-    "[[<-", c("CategoricalArrayVariable", "character", "missing", "ANY"),
+    "[[<-", c("ArrayVariable", "character", "missing", "ANY"),
     function(x, i, value) {
         i <- match(i, names(x))
         if (is.na(i)) {
@@ -301,7 +301,7 @@ setMethod(
 )
 #' @rdname crunch-extract
 #' @export
-setMethod("$<-", "CategoricalArrayVariable", function(x, name, value) {
+setMethod("$<-", "ArrayVariable", function(x, name, value) {
     x[[name]] <- value
     return(x)
 })

--- a/R/variable-type.R
+++ b/R/variable-type.R
@@ -34,12 +34,12 @@ is.MultipleResponse <- is.Multiple
 #' @export
 is.CA <- function(x) {
     ## so it doesn't return true for MultipleResponse
-    return(class(x) %in% "CategoricalArrayVariable")
+    return(identical(class(x), class(CategoricalArrayVariable())))
 }
 
 #' @rdname crunch-is
 #' @export
-is.Array <- function(x) inherits(x, "CategoricalArrayVariable")
+is.Array <- function(x) inherits(x, "ArrayVariable")
 
 #' @rdname crunch-is
 #' @export

--- a/R/variable.R
+++ b/R/variable.R
@@ -95,14 +95,14 @@ setMethod("digits<-", "CrunchVariable", function(x, value) {
 
 #' Split an array or multiple-response variable into its CategoricalVariables
 #'
-#' @param x a `CategoricalArrayVariable` or `MultipleResponseVariable`
+#' @param x an `ArrayVariable`
 #' @return invisibly, the API response from DELETEing the array variable
 #' definition. If you [refresh()] the corresponding dataset after
 #' unbinding, you should see the array variable removed and its subvariables
 #' promoted to regular variables.
 #' @export
 unbind <- function(x) {
-    stopifnot(inherits(x, "CategoricalArrayVariable"))
+    stopifnot(inherits(x, "ArrayVariable"))
     ## Delete self and drop cache for variable catalog (parent)
     u <- self(x)
     out <- crPOST(u, body = '{"unbind": {}}')

--- a/man/Subvariables.Rd
+++ b/man/Subvariables.Rd
@@ -6,26 +6,26 @@
 \alias{Subvariables}
 \alias{subvariables}
 \alias{subvariables<-}
-\alias{subvariables,CategoricalArrayVariable-method}
+\alias{subvariables,ArrayVariable-method}
 \alias{subvariables,CrunchVariable-method}
 \alias{subvariables,VariableTuple-method}
-\alias{subvariables<-,CategoricalArrayVariable,ANY-method}
-\alias{subvariables<-,CategoricalArrayVariable,Subvariables-method}
+\alias{subvariables<-,ArrayVariable,ANY-method}
+\alias{subvariables<-,ArrayVariable,Subvariables-method}
 \title{Subvariables in Array Variables}
 \usage{
 subvariables(x)
 
 subvariables(x) <- value
 
-\S4method{subvariables}{CategoricalArrayVariable}(x)
+\S4method{subvariables}{ArrayVariable}(x)
 
 \S4method{subvariables}{CrunchVariable}(x)
 
 \S4method{subvariables}{VariableTuple}(x)
 
-\S4method{subvariables}{CategoricalArrayVariable,ANY}(x) <- value
+\S4method{subvariables}{ArrayVariable,ANY}(x) <- value
 
-\S4method{subvariables}{CategoricalArrayVariable,Subvariables}(x) <- value
+\S4method{subvariables}{ArrayVariable,Subvariables}(x) <- value
 }
 \arguments{
 \item{x}{A Variable or Subvariables object}

--- a/man/crunch-extract.Rd
+++ b/man/crunch-extract.Rd
@@ -140,15 +140,15 @@
 \alias{[<-,Subvariables,character,missing,Subvariables-method}
 \alias{[<-,Subvariables,ANY,missing,Subvariables-method}
 \alias{[<-,Subvariables,ANY,missing,ANY-method}
-\alias{[,CategoricalArrayVariable,character,ANY-method}
-\alias{[,CategoricalArrayVariable,missing,ANY-method}
-\alias{[,CategoricalArrayVariable,missing,character-method}
-\alias{[[,CategoricalArrayVariable,ANY-method}
-\alias{[[,CategoricalArrayVariable,character-method}
-\alias{$,CategoricalArrayVariable-method}
-\alias{[[<-,CategoricalArrayVariable,ANY,missing,ANY-method}
-\alias{[[<-,CategoricalArrayVariable,character,missing,ANY-method}
-\alias{$<-,CategoricalArrayVariable-method}
+\alias{[,ArrayVariable,character,ANY-method}
+\alias{[,ArrayVariable,missing,ANY-method}
+\alias{[,ArrayVariable,missing,character-method}
+\alias{[[,ArrayVariable,ANY-method}
+\alias{[[,ArrayVariable,character-method}
+\alias{$,ArrayVariable-method}
+\alias{[[<-,ArrayVariable,ANY,missing,ANY-method}
+\alias{[[<-,ArrayVariable,character,missing,ANY-method}
+\alias{$<-,ArrayVariable-method}
 \alias{[[,TabBookResult,numeric-method}
 \alias{[[,TabBookResult,character-method}
 \alias{[[,MultitableResult,ANY-method}
@@ -448,23 +448,23 @@
 
 \S4method{[}{Subvariables,ANY,missing,ANY}(x, i) <- value
 
-\S4method{[}{CategoricalArrayVariable,character,ANY}(x, i, j, ..., drop = TRUE)
+\S4method{[}{ArrayVariable,character,ANY}(x, i, j, ..., drop = TRUE)
 
-\S4method{[}{CategoricalArrayVariable,missing,ANY}(x, i, j, ..., drop = TRUE)
+\S4method{[}{ArrayVariable,missing,ANY}(x, i, j, ..., drop = TRUE)
 
-\S4method{[}{CategoricalArrayVariable,missing,character}(x, i, j, ..., drop = TRUE)
+\S4method{[}{ArrayVariable,missing,character}(x, i, j, ..., drop = TRUE)
 
-\S4method{[[}{CategoricalArrayVariable,ANY}(x, i, j, ...)
+\S4method{[[}{ArrayVariable,ANY}(x, i, j, ...)
 
-\S4method{[[}{CategoricalArrayVariable,character}(x, i, j, ...)
+\S4method{[[}{ArrayVariable,character}(x, i, j, ...)
 
-\S4method{$}{CategoricalArrayVariable}(x, name)
+\S4method{$}{ArrayVariable}(x, name)
 
-\S4method{[[}{CategoricalArrayVariable,ANY,missing,ANY}(x, i) <- value
+\S4method{[[}{ArrayVariable,ANY,missing,ANY}(x, i) <- value
 
-\S4method{[[}{CategoricalArrayVariable,character,missing,ANY}(x, i) <- value
+\S4method{[[}{ArrayVariable,character,missing,ANY}(x, i) <- value
 
-\S4method{$}{CategoricalArrayVariable}(x, name) <- value
+\S4method{$}{ArrayVariable}(x, name) <- value
 
 \S4method{[[}{TabBookResult,numeric}(x, i, j, ...)
 

--- a/man/describe-catalog.Rd
+++ b/man/describe-catalog.Rd
@@ -54,7 +54,7 @@
 \alias{names,OrderGroup-method}
 \alias{names,SlideCatalog-method}
 \alias{names<-,SlideCatalog-method}
-\alias{names,CategoricalArrayVariable-method}
+\alias{names,ArrayVariable-method}
 \alias{names,TabBookResult-method}
 \alias{aliases,TabBookResult-method}
 \alias{descriptions,TabBookResult-method}
@@ -165,7 +165,7 @@ dates(x) <- value
 
 \S4method{names}{SlideCatalog}(x) <- value
 
-\S4method{names}{CategoricalArrayVariable}(x)
+\S4method{names}{ArrayVariable}(x)
 
 \S4method{names}{TabBookResult}(x)
 

--- a/man/unbind.Rd
+++ b/man/unbind.Rd
@@ -7,7 +7,7 @@
 unbind(x)
 }
 \arguments{
-\item{x}{a \code{CategoricalArrayVariable} or \code{MultipleResponseVariable}}
+\item{x}{an \code{ArrayVariable}}
 }
 \value{
 invisibly, the API response from DELETEing the array variable

--- a/tests/testthat/test-subvariables.R
+++ b/tests/testthat/test-subvariables.R
@@ -193,7 +193,7 @@ with_mock_crunch({
     test_that("subvar aliases are right padded", {
         with(temp.option(width = 100),
              expect_equal(
-                 format_subvar_aliases_and_names(
+                 format_subvars(
                      c("alias", "long_alias"),
                      c("name1", "name2")
                  ),
@@ -205,7 +205,7 @@ with_mock_crunch({
     test_that("subvar aliases with spaces get backticks", {
         with(temp.option(width = 100),
              expect_equal(
-                 format_subvar_aliases_and_names(
+                 format_subvars(
                      c("alias", "a b"),
                      c("name1", "name2")
                  ),
@@ -218,7 +218,7 @@ with_mock_crunch({
     test_that("subvar names are truncated", {
         with(temp.option(width = 25),
              expect_equal(
-                 format_subvar_aliases_and_names(
+                 format_subvars(
                      c("alias1", "alias2", "a3"),
                      c("name1", "name2 extra", "name3 is very long")
                  ),

--- a/tests/testthat/test-subvariables.R
+++ b/tests/testthat/test-subvariables.R
@@ -184,10 +184,52 @@ with_mock_crunch({
         mr <- refresh(mr)
         expect_identical(showSubvariables(subvariables(mr)), c(
             "Subvariables:",
-            "  $`First`",
-            "  $`Second`",
-            "  $`Last`"
+            "  $subvar2  | First",
+            "  $subvar1  | Second",
+            "  $subvar3  | Last"
         ))
+    })
+
+    test_that("subvar aliases are right padded", {
+        with(temp.option(width = 100),
+             expect_equal(
+                 format_subvar_aliases_and_names(
+                     c("alias", "long_alias"),
+                     c("name1", "name2")
+                 ),
+                 c("  $alias       | name1", "  $long_alias  | name2")
+             )
+        )
+    })
+
+    test_that("subvar aliases with spaces get backticks", {
+        with(temp.option(width = 100),
+             expect_equal(
+                 format_subvar_aliases_and_names(
+                     c("alias", "a b"),
+                     c("name1", "name2")
+                 ),
+                 c("  $alias  | name1", "  $`a b`  | name2")
+             )
+        )
+
+    })
+
+    test_that("subvar names are truncated", {
+        with(temp.option(width = 25),
+             expect_equal(
+                 format_subvar_aliases_and_names(
+                     c("alias1", "alias2", "a3"),
+                     c("name1", "name2 extra", "name3 is very long")
+                 ),
+                 c(
+                     "  $alias1  | name1",
+                     "  $alias2  | name2 extra",
+                     "  $a3      | name3 is ..."
+                 )
+             )
+        )
+
     })
 })
 


### PR DESCRIPTION
Trying to split out the numeric array work into smaller PRs. This is preparatory work to make an `ArrayVariable` super (virtual) class and improve the array variable printing. 

Some examples of the new array variable printing printing. It now shows both the alias and the name (instead of just the name), alligns the start of the names, and truncates if the name is going to extend past the edge of the console.
```
ds$array1
#> First array (categorical_array)
#> Subvariables:
#>   $var                 | a variable name
#>   $a_longer_var_alias  | another variable name that is so long that it will get trun...
```
