### PR TITLE
Deprecate "each"

### DIFF
--- a/R/formula.R
+++ b/R/formula.R
@@ -210,20 +210,26 @@ varToDim <- function(x) {
     ## as dimensions
     v <- zcl(x)
     if (is.MR(x)) {
-        ## Multiple response gets "as_selected" by default and "each"
-        return(list(list(each = self(x)), zfunc("as_selected", v)))
-    } else if (is.CA(x)) {
-        ## Categorical array gets the var reference and "each"
-        ## Put "each" first so that the rows, not columns, are subvars
+        ## Multiple response gets "as_selected" by default and subvars dimension
         return(list(
-            list(each = self(x)),
+            zfunc("dimension", zfunc("as_selected", v), list(value = "subvariables")),
+            zfunc("as_selected", v)
+        ))
+    } else if (is.CA(x)) {
+        ## Categorical array gets the subvariables dimension first
+        ## and then itself so that the rows, not columns, are subvars
+        return(list(
+            zfunc("dimension", x, list(value = "subvariables")),
             v
         ))
     } else if (is.zfunc(x, "as_array")) {
         ## Pseudo-ZCL from registerCubeFunctions, used to treat an MR like a CA
         ## x is thus list(`function`="as_array", args=list(list(variable=self)))
-        ## Return instead list(list(each=self), list(variable=self))
-        return(list(list(each = x$args[[1]]$variable), x$args[[1]]))
+        ## Return instead subvar dimension + variable
+        return(list(
+            zfunc("dimension", x$args[[1]]["variable"], list(value = "subvariables")),
+            x$args[[1]]["variable"]
+        ))
     } else if (is.CrunchExpr(x)) {
         ## Give a name and alias "references"
         ref <- formatExpression(x)

--- a/R/show.R
+++ b/R/show.R
@@ -373,10 +373,10 @@ showMultitable <- function(x) {
     out <- c(
         out, "Column variables:",
         vapply(x@body$template, function(expr) {
-            if ("each" %in% names(expr$query[[1]])) {
-                # if the first element of the query is each, then this is
-                # an array so take the second argument instead.
-                exprToFormat <- expr$query[[2]]
+            if ((expr$query[[1]][["function"]] %||% "") == "dimension") {
+                # if the first element of the query is a dimension func, then this is
+                # an array, so take the second arg
+                exprToFormat <- expr$query[[1]][["args"]][[1]]
 
                 # if the second arg is a as_selected take the variable from
                 # that to display var only

--- a/tests/testthat/test-cube-mr.R
+++ b/tests/testthat/test-cube-mr.R
@@ -455,30 +455,31 @@ with_mock_crunch({
         expect_GET(
             crtabs(~mymrset, data = ds),
             paste0(
-                "https://app.crunch.io/api/datasets/1/cube/?query=%7B%22dimension",
-                "s%22%3A%5B%7B%22each%22%3A%22https%3A%2F%2Fapp.crunch.io%2Fapi%2F",
-                "datasets%2F1%2Fvariables%2Fmymrset%2F%22%7D%2C%7B%22function%22%3A%22",
-                "as_selected%22%2C%22args%22%3A%5B%7B%22variable%22%3A%22https%3A%2F%2F",
-                "app.crunch.io%2Fapi%2Fdatasets%2F1%2Fvariables%2Fmymrset",
-                "%2F%22%7D%5D%7D%5D%2C%22measures%22%3A%7B%22count%22%3A%7B%22",
-                "function%22%3A%22cube_count%22%2C%22args%22%3A%5B%5D%7D%7D%2C%22",
-                "weight%22%3Anull%7D&filter=%7B%7D"
+                "https://app.crunch.io/api/datasets/1/cube/?query=%7B%22dimensions",
+                "%22%3A%5B%7B%22function%22%3A%22dimension%22%2C%22args%22%3A%5B%7B%22",
+                "function%22%3A%22as_selected%22%2C%22args%22%3A%5B%7B%22variable%22%3A%22",
+                "https%3A%2F%2Fapp.crunch.io%2Fapi%2Fdatasets%2F1%2Fvariables%2Fmymrset%2F",
+                "%22%7D%5D%7D%2C%7B%22value%22%3A%22subvariables%22%7D%5D%7D%2C%7B%22function",
+                "%22%3A%22as_selected%22%2C%22args%22%3A%5B%7B%22variable%22%3A%22https%3A%2F%2F",
+                "app.crunch.io%2Fapi%2Fdatasets%2F1%2Fvariables%2Fmymrset%2F%22%7D%5D%7D%5D%2C",
+                "%22measures%22%3A%7B%22count%22%3A%7B%22function%22%3A%22cube_count%22%2C%22",
+                "args%22%3A%5B%5D%7D%7D%2C%22weight%22%3Anull%7D&filter=%7B%7D"
             )
         )
 
         expect_GET(
             crtabs(~ mymrset + location, data = ds),
             paste0(
-                "https://app.crunch.io/api/datasets/1/cube/?query=%7B%22",
-                "dimensions%22%3A%5B%7B%22each%22%3A%22https%3A%2F%2F",
-                "app.crunch.io%2Fapi%2Fdatasets%2F1%2Fvariables%2Fmymrset",
-                "%2F%22%7D%2C%7B%22function%22%3A%22as_selected%22%2C%22args",
-                "%22%3A%5B%7B%22variable%22%3A%22https%3A%2F%2Fapp.crunch.io",
-                "%2Fapi%2Fdatasets%2F1%2Fvariables%2Fmymrset%2F%22%7D%5D%7D%2C%7B%22",
-                "variable%22%3A%22https%3A%2F%2Fapp.crunch.io%2Fapi%2Fdatasets",
-                "%2F1%2Fvariables%2Flocation%2F%22%7D%5D%2C%22measures%22%3A%7B%22",
-                "count%22%3A%7B%22function%22%3A%22cube_count%22%2C%22args",
-                "%22%3A%5B%5D%7D%7D%2C%22weight%22%3Anull%7D&filter=%7B%7D"
+                "https://app.crunch.io/api/datasets/1/cube/?query=%7B%22dimensions",
+                "%22%3A%5B%7B%22function%22%3A%22dimension%22%2C%22args%22%3A%5B%7B%22",
+                "function%22%3A%22as_selected%22%2C%22args%22%3A%5B%7B%22variable%22%3A",
+                "%22https%3A%2F%2Fapp.crunch.io%2Fapi%2Fdatasets%2F1%2Fvariables%2Fmymrset",
+                "%2F%22%7D%5D%7D%2C%7B%22value%22%3A%22subvariables%22%7D%5D%7D%2C%7B%22function",
+                "%22%3A%22as_selected%22%2C%22args%22%3A%5B%7B%22variable%22%3A%22https%3A%2F%2F",
+                "app.crunch.io%2Fapi%2Fdatasets%2F1%2Fvariables%2Fmymrset%2F%22%7D%5D%7D%2C%7B%22",
+                "variable%22%3A%22https%3A%2F%2Fapp.crunch.io%2Fapi%2Fdatasets%2F1%2Fvariables%2F",
+                "location%2F%22%7D%5D%2C%22measures%22%3A%7B%22count%22%3A%7B%22function%22%3A%22",
+                "cube_count%22%2C%22args%22%3A%5B%5D%7D%7D%2C%22weight%22%3Anull%7D&filter=%7B%7D"
             )
         )
     })

--- a/tests/testthat/test-cube-with-expression.R
+++ b/tests/testthat/test-cube-with-expression.R
@@ -30,7 +30,10 @@ with_mock_crunch({
             formulaToCubeQuery(~ gender + catarray, data = ds),
             '{"dimensions":[
                 {"variable":"https://app.crunch.io/api/datasets/1/variables/gender/"},
-                {"each":"https://app.crunch.io/api/datasets/1/variables/catarray/"},
+                {"function":"dimension","args":[
+                    {"variable":"https://app.crunch.io/api/datasets/1/variables/catarray/"},
+                    {"value":"subvariables"}
+                ]},
                 {"variable":"https://app.crunch.io/api/datasets/1/variables/catarray/"}
                 ],
             "measures":{"count":{"function":"cube_count","args":[]}}}'
@@ -39,11 +42,15 @@ with_mock_crunch({
             formulaToCubeQuery(~ gender + as_selected(mymrset), data = ds),
             paste0(
                 '{"dimensions":[
-                {"variable":"https://app.crunch.io/api/datasets/1/variables/gender/"},
-                {"each":"https://app.crunch.io/api/datasets/1/variables/mymrset/"},
-                {"function": "as_selected",
-                    "args": [{"variable":',
-                '"https://app.crunch.io/api/datasets/1/variables/mymrset/"}]}
+                    {"variable":"https://app.crunch.io/api/datasets/1/variables/gender/"},
+                    {"function":"dimension","args":[
+                        {"function":"as_selected","args":[
+                            {"variable":"https://app.crunch.io/api/datasets/1/variables/mymrset/"}
+                        ]},
+                        {"value":"subvariables"}
+                    ]},
+                    {"function": "as_selected","args": [
+                        {"variable":"https://app.crunch.io/api/datasets/1/variables/mymrset/"}]}
                 ],
             "measures":{"count":{"function":"cube_count","args":[]}}}'
             )
@@ -73,7 +80,10 @@ with_mock_crunch({
             formulaToCubeQuery(~ gender + as_array(mymrset), data = ds),
             '{"dimensions":[
                 {"variable":"https://app.crunch.io/api/datasets/1/variables/gender/"},
-                {"each":"https://app.crunch.io/api/datasets/1/variables/mymrset/"},
+                {"function":"dimension","args":[
+                    {"variable":"https://app.crunch.io/api/datasets/1/variables/mymrset/"},
+                    {"value":"subvariables"}
+                ]},
                 {"variable":"https://app.crunch.io/api/datasets/1/variables/mymrset/"}
                 ],
             "measures":{"count":{"function":"cube_count","args":[]}}}'

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -53,8 +53,17 @@ with_mock_crunch({
             formulaToQuery(~as_selected(ds$mymrset)),
             list(
                 dimensions = list(list(
-                    list(each = self(ds$mymrset)),
-                    list(`function` = "as_selected", args = list(list(variable = self(ds$mymrset))))
+                    list(`function` = "dimension", args = list(
+                         list(
+                             `function` = "as_selected",
+                             args = list(list(variable = self(ds$mymrset)))
+                         ),
+                         list(value = "subvariables")
+                    )),
+                    list(
+                        `function` = "as_selected",
+                        args = list(list(variable = self(ds$mymrset)))
+                    )
                 )),
                 measures = list(count = list(`function` = "cube_count", args = list()))
             )
@@ -66,7 +75,12 @@ with_mock_crunch({
             formulaToQuery(~as_array(ds$mymrset)),
             list(
                 dimensions = list(list(
-                    list(each = self(ds$mymrset)),
+                    list(
+                        "function" = "dimension",
+                        args = list(
+                            list(variable = self(ds$mymrset)), list(value = "subvariables")
+                        )
+                    ),
                     list(variable = self(ds$mymrset))
                 )),
                 measures = list(count = list(`function` = "cube_count", args = list()))

--- a/tests/testthat/test-multitables.R
+++ b/tests/testthat/test-multitables.R
@@ -120,10 +120,10 @@ with_mock_crunch({
             '{"element":"shoji:entity","body":{',
             '"template":[{"query":[{"variable":"https://app.crunch.io/api/',
             'datasets/1/variables/gender/"}]},',
-            '{"query":[{"each":"https://app.crunch.io/api/datasets/1/variables/mymrset/"},',
-            '{"function":"as_selected","args":[{"variable":"https://app.crunch.io/',
-            'api/datasets/1/variables/mymrset/"}]}',
-            "]}]",
+            '{"query":[{"function":"dimension","args":[{"function":"as_selected",',
+            '"args":[{"variable":"https://app.crunch.io/api/datasets/1/variables/mymrset/"}]},',
+            '{"value":"subvariables"}]},{"function":"as_selected","args":[{"variable":',
+            '"https://app.crunch.io/api/datasets/1/variables/mymrset/"}]}]}]',
             ',"name":"New multitable","is_public":true}}'
         )
         with_POST("https://app.crunch.io/api/datasets/1/multitables/4de322/", {
@@ -142,10 +142,10 @@ with_mock_crunch({
             '{"element":"shoji:entity","body":{',
             '"template":[{"query":[{"variable":"https://app.crunch.io/api/datasets',
             '/1/variables/gender/"}]},', # nolint
-            '{"query":[{"each":"https://app.crunch.io/api/datasets/1/variables/mymrset/"},',
-            '{"function":"as_selected","args":[{"variable":"https://app.crunch.io',
-            '/api/datasets/1/variables/mymrset/"}]}', # nolint
-            "]}]",
+            '{"query":[{"function":"dimension","args":[{"function":"as_selected",',
+            '"args":[{"variable":"https://app.crunch.io/api/datasets/1/variables/mymrset/"}]},',
+            '{"value":"subvariables"}]},{"function":"as_selected","args":[{"variable":',
+            '"https://app.crunch.io/api/datasets/1/variables/mymrset/"}]}]}]',
             ',"name":"gender + mymrset"}}'
         )
         with_POST("https://app.crunch.io/api/datasets/1/multitables/4de322/", {

--- a/vignettes/crunch/5/api/datasets/c25696/cube-3c9429.json
+++ b/vignettes/crunch/5/api/datasets/c25696/cube-3c9429.json
@@ -1,6 +1,6 @@
 {
     "element": "shoji:view",
-    "self": "/api/datasets/c25696/cube/?query=%7B%22dimensions%22%3A%5B%7B%22each%22%3A%22%2Fapi%2Fdatasets%2Fc25696%2Fvariables%2F6af3ce%2F%22%7D%2C%7B%22function%22%3A%22as_selected%22%2C%22args%22%3A%5B%7B%22variable%22%3A%22%2Fapi%2Fdatasets%2Fc25696%2Fvariables%2F6af3ce%2F%22%7D%5D%7D%5D%2C%22measures%22%3A%7B%22count%22%3A%7B%22function%22%3A%22cube_count%22%2C%22args%22%3A%5B%5D%7D%7D%7D&filter=%7B%7D",
+    "self": "/api/datasets/c25696/cube/?query=%7B%22dimensions%22%3A%5B%7B%22function%22%3A%22dimension%22%2C%22args%22%3A%5B%7B%22function%22%3A%22as_selected%22%2C%22args%22%3A%5B%7B%22variable%22%3A%22%2Fapi%2Fdatasets%2Fc25696%2Fvariables%2F6af3ce%2F%22%7D%5D%7D%2C%7B%22value%22%3A%22subvariables%22%7D%5D%7D%2C%7B%22function%22%3A%22as_selected%22%2C%22args%22%3A%5B%7B%22variable%22%3A%22%2Fapi%2Fdatasets%2Fc25696%2Fvariables%2F6af3ce%2F%22%7D%5D%7D%5D%2C%22measures%22%3A%7B%22count%22%3A%7B%22function%22%3A%22cube_count%22%2C%22args%22%3A%5B%5D%7D%7D%7D&filter=%7B%7D",
     "value": {
         "query": {
             "measures": {
@@ -13,7 +13,20 @@
             },
             "dimensions": [
                 {
-                    "each": "/api/datasets/c25696/variables/6af3ce/"
+                    "function": "dimension",
+                    "args": [
+                        {
+                            "function": "as_selected",
+                            "args": [
+                                {
+                                    "variable": "/api/datasets/c25696/variables/6af3ce/"
+                                }
+                            ]
+                        },
+                        {
+                            "value": "subvariables"
+                        }
+                    ]
                 },
                 {
                     "function": "as_selected",


### PR DESCRIPTION
Use the `dimension` function to specify the dimensions of an array variable rather than the deprecated "each" function. Most of these changes were to fixtures.