### PR TITLE
Array tweaks

### DIFF
--- a/R/make-array.R
+++ b/R/make-array.R
@@ -47,6 +47,9 @@ makeArray <- function(subvariables, name, ...) {
         ## as in, if the list of variables is a [ extraction from a Dataset
         subvariables <- allVariables(subvariables)
     }
+    if (!(inherits(subvariables, "VariableCatalog") || is.list(subvariables))) {
+        halt("Expected subvariables to be either a variables catalog or list of variables")
+    }
 
     if (!length(subvariables)) {
         halt("No variables supplied")
@@ -284,7 +287,7 @@ makeFrame <- function(x, numeric = NULL) {
     }
 
     # if it's a list, it could contain variable definitions:
-    if (is.list(x)) {
+    if (is.list(x) & !is.VarDef(x)) {
         x <- x[lengths(x) > 0] # remove NULLs (from eg slider)
         subvar_types <- vapply(x, function(sv) {
             if (is.VarDef(sv)) return("vardef")
@@ -292,9 +295,12 @@ makeFrame <- function(x, numeric = NULL) {
             else return("unknown")
         }, character(1))
         x <- lapply(x, zcl)
-    } else { # but ShojiCatalogs don't give their urls when lapplying, so treat differently
+    } else if (inherits(x, "VariableCatalog")) {
+        # but ShojiCatalogs don't give their urls when lapplying, so treat differently
         subvar_types <- types(x)
         x <- lapply(urls(x), function(sv) list(variable = sv))
+    } else {
+        halt("Expected a Variable Catalog or a list of Variables/Expressions/VarDefs")
     }
 
     numeric <- check_make_frame_type_arg(numeric, subvar_types)

--- a/R/variable-type.R
+++ b/R/variable-type.R
@@ -89,6 +89,13 @@ setMethod("type", "CrunchVariable", function(x) type(tuple(x)))
 #' @export
 setMethod("type", "VariableEntity", function(x) x@body$type)
 
+# It's also nice sometimes if a list of variables has a `types` method
+#' @export
+#' @rdname describe-catalog
+setMethod("types", "list", function(x) {
+    vapply(x, type, character(1), USE.NAMES = FALSE)
+})
+
 castVariable <- function(x, value) {
     if (!(type(x) %in% CASTABLE_TYPES)) {
         halt("Cannot change the type of a ", class(x), " by type<-")

--- a/man/describe-catalog.Rd
+++ b/man/describe-catalog.Rd
@@ -4,7 +4,7 @@
 %   R/cube-variables.R, R/dataset.R, R/shoji-catalog.R, R/decks.R,
 %   R/multitables.R, R/shoji-folder.R, R/shoji-order-slots.R, R/slides.R,
 %   R/subvariables.R, R/tab-book.R, R/variable-catalog.R, R/variable-folder.R,
-%   R/versions.R
+%   R/variable-type.R, R/versions.R
 \name{aliases}
 \alias{aliases}
 \alias{describe-catalog}
@@ -70,6 +70,7 @@
 \alias{types,VariableCatalog-method}
 \alias{ids,VariableCatalog-method}
 \alias{aliases,VariableFolder-method}
+\alias{types,list-method}
 \alias{names,VersionCatalog-method}
 \alias{descriptions,VersionCatalog-method}
 \alias{timestamps,VersionCatalog-method}
@@ -196,6 +197,8 @@ dates(x) <- value
 \S4method{ids}{VariableCatalog}(x)
 
 \S4method{aliases}{VariableFolder}(x)
+
+\S4method{types}{list}(x)
 
 \S4method{names}{VersionCatalog}(x)
 

--- a/tests/testthat/test-expressions.R
+++ b/tests/testthat/test-expressions.R
@@ -360,6 +360,18 @@ with_mock_crunch({
         )
     })
 
+    test_that("makeFrame errors on single subvar", {
+        expect_error(
+            deriveArray(
+                subvariables = VariableDefinition(ds$gender == "Male", name = "male"),
+                name = "Gender MR"
+            ),
+            "Expected a Variable Catalog or a list of Variables/Expressions/VarDefs",
+            fixed = TRUE
+        )
+
+    })
+
     test_that("selectCategories expr", {
         expr <- selectCategories(ds$gender, "Male")
         expect_is(expr, "CrunchExpr")

--- a/tests/testthat/test-make-array.R
+++ b/tests/testthat/test-make-array.R
@@ -12,6 +12,16 @@ with_mock_crunch({
             )
         )
     })
+    test_that("makeArray creates a VariableDefinition with list of variables", {
+        expect_json_equivalent(
+            makeArray(list(ds$gender), name = "Gender array"),
+            list(
+                name = "Gender array",
+                subvariables = I("https://app.crunch.io/api/datasets/1/variables/gender/"),
+                type = "categorical_array"
+            )
+        )
+    })
     test_that("makeArray creates a VariableDefinition with variables subset", {
         expect_json_equivalent(
             makeArray(variables(ds)[names(ds) == "gender"],

--- a/tests/testthat/test-make-array.R
+++ b/tests/testthat/test-make-array.R
@@ -52,6 +52,7 @@ with_mock_crunch({
         "Must provide the names of the category or",
         "categories that indicate the dichotomous selection"
     )
+    wrong.type <- "Expected subvariables to be either"
     invalid.selection <- "not found in variable's categories"
     not.categorical <- "are not Categorical"
     test_that("makeArray error conditions", {
@@ -60,6 +61,10 @@ with_mock_crunch({
         expect_error(
             makeArray(ds[grep("NO variables", names(ds))], name = "foo"),
             no.match
+        )
+        expect_error(
+            makeArray(ds$gender, name = "foo"),
+            wrong.type
         )
     })
     test_that("makeMR error conditions", {

--- a/tests/testthat/test-variable-type.R
+++ b/tests/testthat/test-variable-type.R
@@ -40,6 +40,10 @@ with_mock_crunch({
             )
         }
     })
+
+    test_that("`types` list dispatch works", {
+        expect_equal(types(list(ds$birthyr, ds$mymrset)), c("numeric", "multiple_response"))
+    })
 })
 
 with_test_authentication({


### PR DESCRIPTION
Better error message for the case that you expect  `deriveArray` and `makeArray` to have subvariables in `...` argument and re-allow lists of variables to be used in `makeArray()`.