### PR TITLE
Num array cube

### DIFF
--- a/R/formula.R
+++ b/R/formula.R
@@ -215,9 +215,12 @@ varToDim <- function(x) {
             zfunc("dimension", zfunc("as_selected", v), list(value = "subvariables")),
             zfunc("as_selected", v)
         ))
-    } else if (is.CA(x)) {
+    } else if (is.CA(x) | is.NumericArray(x)) {
         ## Categorical array gets the subvariables dimension first
         ## and then itself so that the rows, not columns, are subvars
+        ## We treat numeric arrays as categoricals when used bare
+        ## in formulas like this too so that eg `table(ds$numarray)`
+        ## matches expectations.
         return(list(
             zfunc("dimension", x, list(value = "subvariables")),
             v

--- a/man/getDimTypes.Rd
+++ b/man/getDimTypes.Rd
@@ -15,14 +15,14 @@ the array variable types are more specific.
 }
 \description{
 This function returns the specific type of each cube dimension. This is useful
-when cubes contain categorical array or multiple response variables because it
-identifies the dimensions of the cube which refer to the different parts of
-array variable:
+when cubes contain array variables because it identifies the dimensions of
+the cube which refer to the different parts of array variable:
 \itemize{
 \item \code{ca_items}: Categorical array items
 \item \code{ca_categories}: The categories of the categorical array
 \item \code{mr_items}: Multiple response options or items
 \item \code{mr_selections}: The selection status for a multiple response variable
+\item \code{numarray_items}: Numeric array items
 }
 }
 \keyword{internal}

--- a/tests/testthat/test-cube-dims.R
+++ b/tests/testthat/test-cube-dims.R
@@ -23,6 +23,21 @@ test_that("getDimTypes returns the expected cube dimension types", {
         getDimTypes(cattarray_cat),
         c("ca_items", "ca_categories", "categorical")
     )
+    numa <- loadCube(test_path("cubes/numa.json"))
+    expect_equivalent(
+        getDimTypes(numa),
+        c("numarray_items")
+    )
+    numa_cat <- loadCube(test_path("cubes/numa-x-cat.json"))
+    expect_equivalent(
+        getDimTypes(numa_cat),
+        c("categorical", "numarray_items")
+    )
+    numa_mr <- loadCube(test_path("cubes/numa-x-mr.json"))
+    expect_equivalent(
+        getDimTypes(numa_mr),
+        c("mr_items", "mr_selections", "numarray_items")
+    )
 })
 
 with_mock_crunch({


### PR DESCRIPTION
A simple way to handle numeric arrays in cubes, when the first measure can be identified as a numeric array (the measure has metadata with object type that has subvariables, matching what the cr.cube does) we inflate a single "measure axis" that comes with most measures of numeric arrays and adds it as an equal to the other cube dimensions.


I see 2 issues with this approach:
1) (probably not a big deal): This approach can get confused with complex cubes with some measures based on a numeric array and others aren't.
2) (probably will need a different strategy when as we continue to support num arrays): Not all measures based on numeric arrays have one dimension, eg covariance matrix has 2, so I think we need a separate the concepts of "measure axis" vs "cube dimension" and keep track of which is which)