### PR TITLE
Fixes for tabbook found when adding support for numeric arrays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ License: LGPL (>= 3)
 Depends:
     R (>= 3.0.0)
 Imports:
+    abind,
     crayon,
     curl,
     grDevices,

--- a/R/formula.R
+++ b/R/formula.R
@@ -215,9 +215,12 @@ varToDim <- function(x) {
             zfunc("dimension", zfunc("as_selected", v), list(value = "subvariables")),
             zfunc("as_selected", v)
         ))
-    } else if (is.CA(x)) {
+    } else if (is.CA(x) | is.NumericArray(x)) {
         ## Categorical array gets the subvariables dimension first
         ## and then itself so that the rows, not columns, are subvars
+        ## We treat numeric arrays as categoricals when used bare
+        ## in formulas like this too so that eg `table(ds$numarray)`
+        ## matches expectations.
         return(list(
             zfunc("dimension", x, list(value = "subvariables")),
             v

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -219,36 +219,56 @@ setMethod("initialize", "MultitableResult", function(.Object, ...) {
         ))
     )
     .Object$result <- lapply(.Object$result, function(cube) {
-        cube <- CrunchCube(cube)
-        ## TODO: refactor with CrunchCubep-native methods (eg, dimensions<-, aperm)
-        if (length(dim(cube)) == 3L) {
-            ## check if there is an MR, in which case there are actually 4 dims
-            ## underlyingly, not 3 dims
-            selecteds <- is.selectedDimension(cube@dims)
-            if (any(which(selecteds) %in% c(3, 4))) {
-                ## the selected dimension is in the second half of the cube, so
-                ## the MR is in the multitable
-                cube@dims <- CubeDims(cube@dims[c(2, 3, 4, 1)])
-                cube@arrays <- lapply(cube@arrays, aperm, perm = c(2, 3, 4, 1))
-            } else if (any(which(selecteds) %in% c(1, 2))) {
-                ## the selected dimension is in the first half of the cube, so
-                ## the array is in the multitable
-                cube@dims <- CubeDims(cube@dims[c(4, 3, 1, 2)])
-                cube@arrays <- lapply(cube@arrays, aperm, perm = c(4, 3, 1, 2))
-            } else {
-                ## If cubes are 3D (categorical array x multitable), aperm the
-                ## cubes so that column is multitable var (3 -> 2), row is
-                ## category of array (2 -> 1), subvar is "tab" (1 -> 3)
-                ## TODO: check if it is cat by multitable catarray?
-                cube@dims <- CubeDims(cube@dims[c(2, 3, 1)])
-                cube@arrays <- lapply(cube@arrays, aperm, perm = c(2, 3, 1))
-            }
-        }
-        return(cube)
+        rearrange3DTabbookDims(CrunchCube(cube))
     })
 
     return(.Object)
 })
+
+# Tabbook cubes can only have 3 dimensions if they have a cat/numeric array
+# somewhere. At the time of writing, there is no validation on the template,
+# so it is possible it could be in either the template or the row variables.
+# This code preserves the legacy behavior where we have special logic to handle
+# the situation where categorical arrays
+# (see https://www.pivotaltracker.com/n/projects/2172644/stories/176401734)
+# NB: Tabbooks have 2 variables per cube, so there cannot be a 3D cube with
+# more than 1 selected dimension (2 MRs would be a 2D cube).
+# The goal is to have the dimensions be rearranged so that it's c(2, 3, 1)
+# but need to keep the MR together
+rearrange3DTabbookDims <- function(cube) {
+    if (length(dim(cube)) != 3L) return(cube)
+    ## TODO: refactor with CrunchCubep-native methods (eg, dimensions<-, aperm)
+
+    ## check if there is an MR, in which case there are actually 4 dims
+    ## underlyingly, not 3 dims
+    selecteds <- is.selectedDimension(cube@dims)
+    if (!any(selecteds)) {
+        ## If cubes are categorical array x multitable (non-array), aperm the
+        ## cubes so that column is multitable var (3 -> 2), row is
+        ## category of array (2 -> 1), subvar is "tab" (1 -> 3)
+        dim_order <- c(2, 3, 1)
+    } else if (any(which(selecteds) %in% c(3, 4))) {
+        ## the selected dimension is in the second half of the cube, so
+        ## the MR is in the multitable
+        ## The "3rd dimension" is actually c(3, 4), so dim_order is:
+        ## c(2, (3, 4), 1)
+        dim_order <- c(2, 3, 4, 1)
+    } else if (any(which(selecteds) %in% c(1, 2))) {
+        ## the selected dimension is in the first half of the cube, so
+        ## the array is in the multitable. (This shouldn't really be allowed)
+        ## The "first" dimension is actually c(1, 2), so it would be:
+        ## c(3, 4, (1, 2))
+        ## However, to match legacy behavior, we do 4, 3, 1, 2,
+        ## Greg isn't really sure why we do this, but since it only
+        ## comes up when there's a cat array in the template,
+        ## I just leave it as is.
+        dim_order <- c(4, 3, 1, 2)
+    }
+
+    cube@dims <- CubeDims(cube@dims[dim_order])
+    cube@arrays <- lapply(cube@arrays, aperm, perm = dim_order)
+    return(cube)
+}
 
 #' @rdname crunch-extract
 #' @export

--- a/R/tab-book.R
+++ b/R/tab-book.R
@@ -182,7 +182,7 @@ setMethod("dim", "TabBookResult", function(x) {
 #' @rdname describe-catalog
 #' @export
 setMethod("names", "TabBookResult", function(x) {
-    unlist(lapply(x$meta$sheets, function(sheet) sheet$name))
+    unlist(lapply(x$meta$analyses, function(sheet) sheet$name))
 })
 #' @rdname describe-catalog
 #' @export

--- a/man/getDimTypes.Rd
+++ b/man/getDimTypes.Rd
@@ -15,14 +15,14 @@ the array variable types are more specific.
 }
 \description{
 This function returns the specific type of each cube dimension. This is useful
-when cubes contain categorical array or multiple response variables because it
-identifies the dimensions of the cube which refer to the different parts of
-array variable:
+when cubes contain array variables because it identifies the dimensions of
+the cube which refer to the different parts of array variable:
 \itemize{
 \item \code{ca_items}: Categorical array items
 \item \code{ca_categories}: The categories of the categorical array
 \item \code{mr_items}: Multiple response options or items
 \item \code{mr_selections}: The selection status for a multiple response variable
+\item \code{numarray_items}: Numeric array items
 }
 }
 \keyword{internal}

--- a/mocks/app.crunch.io/api/datasets/1/multitables/apidocs-tabbook.json
+++ b/mocks/app.crunch.io/api/datasets/1/multitables/apidocs-tabbook.json
@@ -26,7 +26,7 @@
                 ]
             }
         ],
-        "sheets": [
+        "analyses": [
             {
                 "display_settings": {
                     "percentageDirection": {

--- a/tests/testthat/app.crunch.io/api/datasets/1/multitables/apidocs-ca-mr-tabbook.json
+++ b/tests/testthat/app.crunch.io/api/datasets/1/multitables/apidocs-ca-mr-tabbook.json
@@ -14,7 +14,7 @@
                 ]
             }
         ],
-        "sheets": [
+        "analyses": [
             {
                 "display_settings": {
                     "percentageDirection": {

--- a/tests/testthat/app.crunch.io/api/datasets/1/multitables/apidocs-mr-ca-tabbook.json
+++ b/tests/testthat/app.crunch.io/api/datasets/1/multitables/apidocs-mr-ca-tabbook.json
@@ -19,7 +19,7 @@
                 ]
             }
         ],
-        "sheets": [
+        "analyses": [
             {
                 "display_settings": {
                     "percentageDirection": {

--- a/tests/testthat/test-cube-dims.R
+++ b/tests/testthat/test-cube-dims.R
@@ -23,6 +23,21 @@ test_that("getDimTypes returns the expected cube dimension types", {
         getDimTypes(cattarray_cat),
         c("ca_items", "ca_categories", "categorical")
     )
+    numa <- loadCube(test_path("cubes/numa.json"))
+    expect_equivalent(
+        getDimTypes(numa),
+        c("numarray_items")
+    )
+    numa_cat <- loadCube(test_path("cubes/numa-x-cat.json"))
+    expect_equivalent(
+        getDimTypes(numa_cat),
+        c("categorical", "numarray_items")
+    )
+    numa_mr <- loadCube(test_path("cubes/numa-x-mr.json"))
+    expect_equivalent(
+        getDimTypes(numa_mr),
+        c("mr_items", "mr_selections", "numarray_items")
+    )
 })
 
 with_mock_crunch({

--- a/tests/testthat/test-multitables.R
+++ b/tests/testthat/test-multitables.R
@@ -8,6 +8,7 @@ test_that("default name for formula", {
 with_mock_crunch({
     ds <- loadDataset("test ds") ## Has 2 multitables
     ds2 <- loadDataset("ECON.sav") ## Has no multitables
+    ds_veg <- loadDataset("Vegetables example") ## Has valid tabbook
     with_POST("https://app.crunch.io/api/datasets/1/filters/filter1/", {
         ## Mock the return of that creation
         f1 <- newFilter("A filter", ds$gender == "Male", catalog = filters(ds))
@@ -394,151 +395,139 @@ with_mock_crunch({
         })
     })
 
-    with_POST("https://app.crunch.io/api/datasets/1/multitables/apidocs-tabbook/", {
-        book <- tabBook(mults[[1]], data = ds, output_format = "json")
-        test_that("tabBook JSON returns TabBookResult", {
-            expect_is(book, "TabBookResult")
-        })
-        test_that("TabBookResult and MultitableResult size/extract methods", {
-            expect_length(book, 9)
-            expect_is(book[[1]], "MultitableResult")
-            expect_length(book[[1]], 3)
-            expect_identical(dim(book), c(9L, 3L))
-            expect_is(book[[1]][[1]], "CrunchCube")
-        })
-        test_that("tab book print methods", {
-            ## Print method for MultitableResult cbinds together the Cubes
-            out <- cubify(
-                4, 4, 0, 1, 0, 1, 1,
-                5, 0, 5, 3, 2, 1, 1,
-                5, 1, 3, 5, 2, 1, 1,
-                dims = list(
-                    c("Cat", "Dog", "Bird"),
-                    c("", "Cat", "Dog", "Bird", "Cat", "Dog", "Bird")
-                )
-            )
-            expect_prints(print(book[[1]]), get_output(out))
-            ## TODO: print method for TabBookResult
-        })
+    with_POST(
+        "https://app.crunch.io/api/datasets/veg/multitables/mt_01/cat-mr-tabbook/", {
+            book <- tabBook(mults[[1]], data = ds, output_format = "json")
+            test_that("tabBook JSON returns TabBookResult", {
+                expect_is(book, "TabBookResult")
+            })
+            test_that("TabBookResult and MultitableResult size/extract methods", {
+                expect_length(book, 9)
+                expect_is(book[[1]], "MultitableResult")
+                expect_length(book[[1]], 3)
+                expect_identical(dim(book), c(9L, 3L))
+                expect_is(book[[1]][[1]], "CrunchCube")
+            })
 
-        test_that("The first result in a MultitableResult has 2 dimensions", {
-            expect_identical(dim(book[[1]][[1]]), c(3L, 1L))
-        })
-        test_that("prop.table methods", {
-            ## prop.table on a TabBookResult returns a list of lists of prop.tables
-            expect_identical(
-                prop.table(book)[[2]][[2]],
-                prop.table(book[[2]][[2]])
-            )
-            expect_identical(
-                prop.table(book, 1)[[2]][[2]],
-                prop.table(book[[2]][[2]], 1)
-            )
-            expect_identical(
-                prop.table(book, 2)[[2]][[2]],
-                prop.table(book[[2]][[2]], 2)
-            )
-        })
+            test_that("MultitableResult print methods - mr+cat template x cat page", {
+                ## Print method for MultitableResult binds together the Cubes
+                out <- cubify(
+                    85,  42, 56, 80, 85,   0,
+                    120, 41, 68, 88,  0, 120,
+                    dims = list(
+                        c("No", "Yes"),
+                        c("", "Savory", "Spicy", "Sweet", "No", "Yes")
+                    )
+                )
+                expect_prints(print(book[[3]]), get_output(out))
+            })
+
+            test_that("MultitableResult print methods - mr+cat template x catarray page", {
+                ## Print method for MultitableResult binds together the Cubes
+                ## And rearranges 3d cubes from Cat array
+                out <- cubify(
+                    44, 73, 19, 20, 19, 30, 7, 8, 32, 48, 12, 14, 42, 57, 17, 16,
+                    26, 38, 15, 10, 16, 34, 4, 10, 28, 21, 57, 17, 12, 6, 21, 4,
+                    17, 13, 29, 14, 21, 19, 47, 16, 11, 9, 29, 9, 16, 11, 26, 8,
+                    13, 21, 65, 45, 6, 10, 28, 18, 6, 15, 38, 20, 10, 20, 56, 36,
+                    4, 10, 29, 16, 9, 10, 36, 28, 90, 55, 16, 101, 33, 24, 7, 43,
+                    57, 32, 10, 67, 73, 44, 14, 83, 33, 18, 8, 41, 55, 36, 8, 56,
+                    18, 33, 45, 15, 6, 13, 19, 7, 7, 16, 34, 7, 14, 25, 30, 10, 2,
+                    8, 4, 5, 16, 25, 38, 10,
+                    dims = list(
+                        c("Strongly Disagree", "Disagree", "Neither", "Agree", "Strongly Agree"),
+                        c("", "Savory", "Spicy", "Sweet", "No", "Yes"),
+                        c("Healthy", "Tasty", "Filling", "Environmental")
+                    )
+                )
+                expect_prints(print(book[[5]]), get_output(out))
+            })
+
+            test_that("MultitableResult print methods - mr+cat template x mr page", {
+                ## Print method for MultitableResult binds together the Cubes
+                out <- cubify(
+                    86,  86,  52,  65, 42, 41,
+                    128, 52, 128, 110, 56, 68,
+                    171, 65, 110, 171, 80, 88,
+                    dims = list(
+                        c("Savory", "Spicy", "Sweet"),
+                        c("", "Savory", "Spicy", "Sweet", "No", "Yes")
+                    )
+                )
+                expect_prints(print(book[[4]]), get_output(out))
+            })
+
+            test_that("MultitableResult print methods - mr+cat template x numeric page", {
+                ## Print method for MultitableResult binds together the Cubes
+                out <- cubify(
+                    41.83920, 37.21250, 44.41667, 42.09375, 41.64103, 42.18803,
+                    dims = list(
+                        c("", "Savory", "Spicy", "Sweet", "No", "Yes")
+                    )
+                )
+                expect_prints(print(book[[2]]), get_output(out))
+            })
+
+            test_that("MultitableResult print methods - mr+cat template x numeric array page", {
+                ## Print method for MultitableResult binds together the Cubes
+                out <- cubify(
+                    72.93659, 72.56471,   73.312, 72.90533, 72.07059,  73.6087,
+                    62.39706, 63.96429,  61.9187, 62.30909, 62.66667, 62.12712,
+                    76.27586, 76.36585, 76.31452, 76.57229, 78.50617, 75.08547,
+                    70.465,   69.43373, 73.68293, 71.87654, 70.06098, 70.50442,
+                    68.31658, 68.97468, 67.61475, 68.44099, 68.26829, 68.08929,
+                    86.67347, 87.21333, 87.16102, 86.86792,    86.95, 86.49107,
+                    dims = list(
+                        c("Avocado", "Brussel Sprout", "Carrot", "Daikon", "Eggplant", "Fennel"),
+                        c("", "Savory", "Spicy", "Sweet", "No", "Yes")
+                    )
+                )
+                expect_prints(print(book[[6]]), get_output(out))
+            })
+
+            test_that("The first result in a MultitableResult has 2 dimensions", {
+                expect_identical(dim(book[[1]][[1]]), c(7L, 1L))
+            })
+            test_that("prop.table methods", {
+                ## prop.table on a TabBookResult returns a list of lists of prop.tables
+                expect_identical(
+                    prop.table(book)[[3]][[2]],
+                    prop.table(book[[3]][[2]])
+                )
+                expect_identical(
+                    prop.table(book, 1)[[3]][[2]],
+                    prop.table(book[[3]][[2]], 1)
+                )
+            })
+
+            test_that("tabBook from apidocs dataset (mock)", {
+                expect_identical(dim(book), c(9L, 3L))
+                expect_identical(
+                    prop.table(book, 1)[[1]][[2]],
+                    prop.table(book[[1]][[2]], 1)
+                )
+            })
+
+            test_that("tab book names", {
+                expect_identical(
+                    names(book)[1:4],
+                    c("Survey Wave", "Age", "Healthy Eater", "Enjoy Food Flavors")
+                )
+                expect_is(book[["Survey Wave"]], "MultitableResult")
+                expect_null(book[["NOTVALID"]])
+            })
+            test_that("tabBook JSON with arrays returns TabBookResult", {
+                expect_is(book, "TabBookResult")
+                expect_identical(
+                    prop.table(book, 1)[[3]][[2]],
+                    prop.table(book[[3]][[2]], 1)
+                )
+            })
+        }
+    )
         ## TODO: something more with variable metadata? For cubes more generally?
         ## --> are descriptions coming from backend if they exist?
 
-        with_POST("https://app.crunch.io/api/datasets/1/multitables/apidocs-mr-ca-tabbook/", {
-            ## This mock was taken from the integration test below
-            book <- tabBook(mults[[1]], data = ds, output_format = "json")
-            test_that("tabBook JSON returns TabBookResult", {
-                expect_is(book, "TabBookResult")
-            })
-            test_that("TabBookResult and MultitableResult size/extract methods", {
-                expect_length(book, 1)
-                expect_is(book[[1]], "MultitableResult")
-                expect_length(book[[1]], 2)
-                expect_identical(dim(book), c(1L, 2L))
-                expect_is(book[[1]][[1]], "CrunchCube")
-            })
-            test_that("tab book print methods", {
-                ## TODO: print method for TabBookResult
-            })
-
-            test_that("The first result in a MultitableResult has 3 dimensions", {
-                expect_identical(dim(showMissing(book[[1]][[1]])), c(5L, 1L, 2L))
-            })
-            test_that("dim names", {
-                expect_identical(
-                    names(book[[1]][[1]]),
-                    c("Pets by location", "Total", "Pets by location")
-                )
-                expect_identical(
-                    names(book[[1]][[2]]),
-                    c(
-                        "Pets by location", "All pets owned",
-                        "Pets by location"
-                    )
-                )
-            })
-        })
-
-        with_POST("https://app.crunch.io/api/datasets/1/multitables/apidocs-ca-mr-tabbook/", {
-            ## This mock was taken from the integration test below
-            book <- tabBook(mults[[1]], data = ds, output_format = "json")
-            test_that("tabBook JSON returns TabBookResult", {
-                expect_is(book, "TabBookResult")
-            })
-            test_that("TabBookResult and MultitableResult size/extract methods", {
-                expect_length(book, 1)
-                expect_is(book[[1]], "MultitableResult")
-                expect_length(book[[1]], 2)
-                expect_identical(dim(book), c(1L, 2L))
-                expect_is(book[[1]][[1]], "CrunchCube")
-            })
-            test_that("tab book print methods", {
-                ## TODO: print method for TabBookResult
-            })
-            test_that("The first result in a MultitableResult has 3 dimensions", {
-                expect_identical(dim(showMissing(book[[1]][[1]])), c(3L, 1L))
-            })
-            test_that("dim names", {
-                expect_identical(
-                    names(book[[1]][[1]]),
-                    c("All pets owned", "Total")
-                )
-                expect_identical(
-                    names(book[[1]][[2]]),
-                    c(
-                        "Pets by location", "Pets by location",
-                        "All pets owned"
-                    )
-                )
-            })
-        })
-    })
-
-    with_POST("https://app.crunch.io/api/datasets/1/multitables/apidocs-tabbook/", {
-        ## This mock was taken from the integration test below
-        book <- tabBook(mults[[1]], data = ds)
-        test_that("tabBook from apidocs dataset (mock)", {
-            expect_is(book, "TabBookResult")
-            expect_identical(dim(book), c(9L, 3L))
-            expect_identical(
-                prop.table(book, 2)[[2]][[2]],
-                prop.table(book[[2]][[2]], 2)
-            )
-        })
-        test_that("tab book names", {
-            expect_identical(
-                names(book)[1:4],
-                c("All pets owned", "Pet", "Pets by location", "Number of dogs")
-            )
-            expect_is(book[["Pet"]], "MultitableResult")
-            expect_null(book[["NOTVALID"]])
-        })
-        test_that("tabBook JSON with arrays returns TabBookResult", {
-            expect_is(book, "TabBookResult")
-            expect_identical(
-                prop.table(book, 2)[[3]][[2]],
-                prop.table(book[[3]][[2]], 2)
-            )
-        })
-    })
 })
 
 with_test_authentication({


### PR DESCRIPTION
Includes #537

When adding support for numeric arrays noticed a few problems with how tabbook pages are printed (because of the way we rearrange cubes) and we'll also have to rearrange the numeric-array dimension.