### PR TITLE
Scorecard query

### DIFF
--- a/R/cube-query.R
+++ b/R/cube-query.R
@@ -1,13 +1,34 @@
 #' Crunch xtabs: Crosstab and otherwise aggregate variables in a Crunch Dataset
 #'
 #' Create a contingency table or other aggregation from cross-classifying
-#' variables in a CrunchDataset.
+#' variables in a CrunchDataset, expanding on the notation allowed in
+#' [`stats::xtabs()`] to tailor to the kinds of calculations available in crunch.
 #'
-#' @param formula an object of class 'formula' object with the
-#' cross-classifying variables separated by '+' on the right side of the
-#' "~". If aggregating by functions other than counts, include the aggregation
-#' expression on the left-hand side.
-#' Compare to [stats::xtabs()].
+#' There are 3 types of queries supported:
+#'
+#' - Crosstabs: Share the most in common with [`stats::xtabs()`], are defined by
+#' a formula with only a right hand side, with each dimension specified on the
+#' right-hand side, separated by a `+`. A dimension are generally variables, but
+#' categorical array variables contribute 2 dimensions, "categories" and "subvariables".
+#' If you just use the categorical array variable directly, the "subvariables" dimensions
+#' will be added first and the "categories" second, but you can choose their order by
+#' specifying both `categories(var)` and `subvariables(var)` (where `var` is a
+#' Categorical Array CrunchVariable).
+#'
+#' - Aggregations: An extension to 'Crosstabs' where you can select one or more
+#' measures by putting them in the left-hand side of the formula. Multiple measures
+#' can be placed in a list to calculate them together. The currently supported
+#' measures are `mean(var)`, `n()` (the same as a crosstab), `min(var)`, `max(var)`,
+#'  `sd(var)`, `sum(var)` and `median(var)` (where `var` is a CrunchVariable).
+#'
+#' - Scorecards: When you want to compare multiple MR variables with the same
+#' subvariables, you can use a scorecard to create a tabulation where they are
+#' lined up. Scorecard queries cannot be combined with the other types. Use
+#' the `scorecard(..., vars = NULL)` (where `...` is a set of MR variables or
+#' `vars` is a list of them).
+#'
+#' @param formula an object of class 'formula' object, that specifies that query
+#' to calculate. See Details for more information.
 #' @param data an object of class `CrunchDataset`
 #' @param weight a CrunchVariable that has been designated as a potential
 #' weight variable for `data`, or `NULL` for unweighted results.
@@ -18,6 +39,30 @@
 #' @importFrom stats as.formula terms
 #' @seealso [weight()]
 #' @export
+#' @examples
+#' \dontrun{
+#' # Crosstab of people by `age_cat`:
+#' crtabs(~age_cat, ds)
+#'
+#' # Aggregation of means of income by `age_cat`
+#' crtabs(mean(income) ~ age_cat, ds)
+#'
+#' # Scorecard of multiple MRs with aligned subvariables
+#' crtabs(~scorecard(trust_mr, value_mr, quality_mr), ds)
+#' # Can also pre-define the variables in a scorecard with
+#' mr_list <- list(ds$trust_mr, ds$value_mr, ds$quality_mr)
+#' crtabs(~scorecard(vars = mr_list), ds)
+#'
+#' # Crosstab of people by `age_cat` and the reasons for enjoying a brand (cat array)
+#' crtabs(~age_cat + enjoy_array, ds)
+#'
+#' # Crosstab of people by `age_cat` and the `enjoy_array` (cat array)
+#' # But manually choosing the order of the dimensions
+#' crtabs(~subvariables(enjoy_array) + age_cat + categories(enjoy_array), ds)
+#'
+#' # Aggregation of means & standard deviations of income by `age_cat`
+#' crtabs(list(mean = mean(income), sd = sd(income)) ~ age_cat, ds)
+#' }
 crtabs <- function(formula, data, weight = crunch::weight(data),
                    useNA = c("no", "ifany", "always")) {
     ## Validate inputs

--- a/R/cube-query.R
+++ b/R/cube-query.R
@@ -9,9 +9,10 @@
 #' - Crosstabs: Share the most in common with [`stats::xtabs()`], are defined by
 #' a formula with only a right hand side, with each dimension specified on the
 #' right-hand side, separated by a `+`. A dimension are generally variables, but
-#' categorical array variables contribute 2 dimensions, "categories" and "subvariables".
-#' If you just use the categorical array variable directly, the "subvariables" dimensions
-#' will be added first and the "categories" second, but you can choose their order by
+#' categorical array variables contribute 2 dimensions, \dQuote{categories} and 
+#' \dQuote{subvariables}.
+#' If you just use the categorical array variable directly, the subvariables dimensions
+#' will be added first and the categories second, but you can choose their order by
 #' specifying both `categories(var)` and `subvariables(var)` (where `var` is a
 #' Categorical Array CrunchVariable).
 #'

--- a/R/cube-query.R
+++ b/R/cube-query.R
@@ -28,7 +28,7 @@
 #' the `scorecard(..., vars = NULL)` (where `...` is a set of MR variables or
 #' `vars` is a list of them).
 #'
-#' @param formula an object of class 'formula' object, that specifies that query
+#' @param formula a [stats::formula] object that specifies that query
 #' to calculate. See Details for more information.
 #' @param data an object of class `CrunchDataset`
 #' @param weight a CrunchVariable that has been designated as a potential

--- a/R/formula.R
+++ b/R/formula.R
@@ -183,8 +183,8 @@ registerCubeFunctions <- function(varnames = c()) {
             zcl(x)
         },
         n = function(...) zfunc("cube_count"),
-        scorecard = function(...) {
-            vars <- list(...)
+        scorecard = function(..., vars = NULL) {
+            vars <- c(list(...), vars)
             if (!all(vapply(vars, function(x) is.MR(x) | is.CrunchExpr(x), logical(1)))) {
                 halt("Expected Multiple Response variables or expressions in a scorecard")
             }

--- a/R/slides.R
+++ b/R/slides.R
@@ -56,6 +56,7 @@ setGeneric("cube", function(x) standardGeneric("cube"))
 #' @export
 setGeneric("cubes", function(x) standardGeneric("cubes"))
 
+#nolint start
 #' Get or set a slide's display settings
 #'
 #' A slide's display settings can be modified by assigning a named list
@@ -64,6 +65,7 @@ setGeneric("cubes", function(x) standardGeneric("cubes"))
 #' https://crunch.io/api/reference/#patch-/datasets/-dataset_id-/decks/-deck_id-/slides/-slide_id-/analyses/-analysis_id-/)
 #' @rdname display-settings
 #' @export
+#nolint end
 setGeneric("displaySettings", function(x) standardGeneric("displaySettings"))
 #' @rdname display-settings
 #' @export

--- a/R/slides.R
+++ b/R/slides.R
@@ -17,7 +17,7 @@
 #' @param x a `CrunchSlide`, `AnalysisCatalog`, or `Analysis`
 #' @param value for the setter, a query
 #' @param query For `formulaToSlideQuery()`, a formula that specifies the query, as in
-#' `newSlide()`
+#' `newSlide()`. See Details of [`crtabs()`] for more information.
 #' @param dataset For `formulaToSlideQuery()`, a `CrunchDataset` that the variables in
 #' `query` refer to.
 #' @param weight For `slideQueryEnv()` a crunch variable to use as a weight or `NULL`
@@ -208,8 +208,8 @@ DEFAULT_DISPLAY_SETTINGS <- list(
 #' Append a new slide to a Crunch Deck
 #'
 #' @param deck A Crunch Deck
-#' @param query A formula definition of a query to be used by the slide. This is
-#' similar to CrunchCube query
+#' @param query A formula definition of a query to be used by the slide. See
+#' Details of [`crtabs()`] for more information about making queries.
 #' @param display_settings (optional) A list of display settings. If omitted,
 #' slide will be a table of column percentages with hypothesis test highlighting
 #' enabled. The most common setting used is `vizType`, which can be:

--- a/R/slides.R
+++ b/R/slides.R
@@ -61,7 +61,7 @@ setGeneric("cubes", function(x) standardGeneric("cubes"))
 #' A slide's display settings can be modified by assigning a named list
 #' @param x a CrunchSlide, Analysis, or AnalysisCatalog
 #' @param value a named list, for valid settings see [API documentation](
-#' https://crunch.io/api/reference/#get-/datasets/-dataset_id-/decks/-deck_id-/slides/-slide_id-/)
+#' https://crunch.io/api/reference/#patch-/datasets/-dataset_id-/decks/-deck_id-/slides/-slide_id-/analyses/-analysis_id-/)
 #' @rdname display-settings
 #' @export
 setGeneric("displaySettings", function(x) standardGeneric("displaySettings"))

--- a/R/slides.R
+++ b/R/slides.R
@@ -507,7 +507,7 @@ setMethod(
         # and update fixtures
         payload <- value@body[
             na.omit(match(
-                c("query", "display_settings", "query_environment", "viz_specs", "transforms"),
+                c("query", "display_settings", "query_environment", "viz_specs", "transform"),
                 names(value@body)
             ))
         ]

--- a/man/analysis-methods.Rd
+++ b/man/analysis-methods.Rd
@@ -100,7 +100,7 @@ slideQueryEnv(weight, filter)
 \item{value}{for the setter, a query}
 
 \item{query}{For \code{formulaToSlideQuery()}, a formula that specifies the query, as in
-\code{newSlide()}}
+\code{newSlide()}. See Details of \code{\link[=crtabs]{crtabs()}} for more information.}
 
 \item{dataset}{For \code{formulaToSlideQuery()}, a \code{CrunchDataset} that the variables in
 \code{query} refer to.}

--- a/man/crtabs.Rd
+++ b/man/crtabs.Rd
@@ -12,11 +12,8 @@ crtabs(
 )
 }
 \arguments{
-\item{formula}{an object of class 'formula' object with the
-cross-classifying variables separated by '+' on the right side of the
-"~". If aggregating by functions other than counts, include the aggregation
-expression on the left-hand side.
-Compare to \code{\link[stats:xtabs]{stats::xtabs()}}.}
+\item{formula}{an object of class 'formula' object, that specifies that query
+to calculate. See Details for more information.}
 
 \item{data}{an object of class \code{CrunchDataset}}
 
@@ -32,7 +29,56 @@ an object of class \code{CrunchCube}
 }
 \description{
 Create a contingency table or other aggregation from cross-classifying
-variables in a CrunchDataset.
+variables in a CrunchDataset, expanding on the notation allowed in
+\code{\link[stats:xtabs]{stats::xtabs()}} to tailor to the kinds of calculations available in crunch.
+}
+\details{
+There are 3 types of queries supported:
+\itemize{
+\item Crosstabs: Share the most in common with \code{\link[stats:xtabs]{stats::xtabs()}}, are defined by
+a formula with only a right hand side, with each dimension specified on the
+right-hand side, separated by a \code{+}. A dimension are generally variables, but
+categorical array variables contribute 2 dimensions, "categories" and "subvariables".
+If you just use the categorical array variable directly, the "subvariables" dimensions
+will be added first and the "categories" second, but you can choose their order by
+specifying both \code{categories(var)} and \code{subvariables(var)} (where \code{var} is a
+Categorical Array CrunchVariable).
+\item Aggregations: An extension to 'Crosstabs' where you can select one or more
+measures by putting them in the left-hand side of the formula. Multiple measures
+can be placed in a list to calculate them together. The currently supported
+measures are \code{mean(var)}, \code{n()} (the same as a crosstab), \code{min(var)}, \code{max(var)},
+\code{sd(var)}, \code{sum(var)} and \code{median(var)} (where \code{var} is a CrunchVariable).
+\item Scorecards: When you want to compare multiple MR variables with the same
+subvariables, you can use a scorecard to create a tabulation where they are
+lined up. Scorecard queries cannot be combined with the other types. Use
+the \code{scorecard(..., vars = NULL)} (where \code{...} is a set of MR variables or
+\code{vars} is a list of them).
+}
+}
+\examples{
+\dontrun{
+# Crosstab of people by `age_cat`:
+crtabs(~age_cat, ds)
+
+# Aggregation of means of income by `age_cat`
+crtabs(mean(income) ~ age_cat, ds)
+
+# Scorecard of multiple MRs with aligned subvariables
+crtabs(~scorecard(trust_mr, value_mr, quality_mr), ds)
+# Can also pre-define the variables in a scorecard with
+mr_list <- list(ds$trust_mr, ds$value_mr, ds$quality_mr)
+crtabs(~scorecard(vars = mr_list), ds)
+
+# Crosstab of people by `age_cat` and the reasons for enjoying a brand (cat array)
+crtabs(~age_cat + enjoy_array, ds)
+
+# Crosstab of people by `age_cat` and the `enjoy_array` (cat array)
+# But manually choosing the order of the dimensions
+crtabs(~subvariables(enjoy_array) + age_cat + categories(enjoy_array), ds)
+
+# Aggregation of means & standard deviations of income by `age_cat`
+crtabs(list(mean = mean(income), sd = sd(income)) ~ age_cat, ds)
+}
 }
 \seealso{
 \code{\link[=weight]{weight()}}

--- a/man/crtabs.Rd
+++ b/man/crtabs.Rd
@@ -12,7 +12,7 @@ crtabs(
 )
 }
 \arguments{
-\item{formula}{an object of class 'formula' object, that specifies that query
+\item{formula}{a \link[stats:formula]{stats::formula} object that specifies that query
 to calculate. See Details for more information.}
 
 \item{data}{an object of class \code{CrunchDataset}}
@@ -38,9 +38,10 @@ There are 3 types of queries supported:
 \item Crosstabs: Share the most in common with \code{\link[stats:xtabs]{stats::xtabs()}}, are defined by
 a formula with only a right hand side, with each dimension specified on the
 right-hand side, separated by a \code{+}. A dimension are generally variables, but
-categorical array variables contribute 2 dimensions, "categories" and "subvariables".
-If you just use the categorical array variable directly, the "subvariables" dimensions
-will be added first and the "categories" second, but you can choose their order by
+categorical array variables contribute 2 dimensions, \dQuote{categories} and
+\dQuote{subvariables}.
+If you just use the categorical array variable directly, the subvariables dimensions
+will be added first and the categories second, but you can choose their order by
 specifying both \code{categories(var)} and \code{subvariables(var)} (where \code{var} is a
 Categorical Array CrunchVariable).
 \item Aggregations: An extension to 'Crosstabs' where you can select one or more

--- a/man/display-settings.Rd
+++ b/man/display-settings.Rd
@@ -33,7 +33,7 @@ displaySettings(x) <- value
 \arguments{
 \item{x}{a CrunchSlide, Analysis, or AnalysisCatalog}
 
-\item{value}{a named list, for valid settings see \href{https://crunch.io/api/reference/#get-/datasets/-dataset_id-/decks/-deck_id-/slides/-slide_id-/}{API documentation}}
+\item{value}{a named list, for valid settings see \href{https://crunch.io/api/reference/#patch-/datasets/-dataset_id-/decks/-deck_id-/slides/-slide_id-/analyses/-analysis_id-/}{API documentation}}
 }
 \description{
 A slide's display settings can be modified by assigning a named list

--- a/man/newSlide.Rd
+++ b/man/newSlide.Rd
@@ -16,8 +16,8 @@ newSlide(
 \arguments{
 \item{deck}{A Crunch Deck}
 
-\item{query}{A formula definition of a query to be used by the slide. This is
-similar to CrunchCube query}
+\item{query}{A formula definition of a query to be used by the slide. See
+Details of \code{\link[=crtabs]{crtabs()}} for more information about making queries.}
 
 \item{display_settings}{(optional) A list of display settings. If omitted,
 slide will be a table of column percentages with hypothesis test highlighting

--- a/tests/testthat/test-cubes.R
+++ b/tests/testthat/test-cubes.R
@@ -503,7 +503,7 @@ with_test_authentication({
         ds_scorecard$x_sel_a<- deriveArray(ds_scorecard[c("x1", "x2")], "x mr - a", selections = "a")
         ds_scorecard$x_sel_b<- deriveArray(ds_scorecard[c("x1", "x2")], "x mr - b", selections = "b")
 
-        scorecard_cube <- crtabs(~scorecard(ds_scorecard$x_sel_a, ds_scorecard$x_sel_b), ds_scorecard)
+        scorecard_cube <- crtabs(~scorecard(x_sel_a, x_sel_b), ds_scorecard)
 
         expect_equal(dimnames(scorecard_cube)[[1]], c("x1", "x2"))
         expect_equal(dimnames(scorecard_cube)[[2]], c("x mr - a", "x mr - b"))

--- a/tests/testthat/test-cubes.R
+++ b/tests/testthat/test-cubes.R
@@ -500,8 +500,12 @@ with_test_authentication({
             ),
             "scorecard test"
         )
-        ds_scorecard$x_sel_a<- deriveArray(ds_scorecard[c("x1", "x2")], "x mr - a", selections = "a")
-        ds_scorecard$x_sel_b<- deriveArray(ds_scorecard[c("x1", "x2")], "x mr - b", selections = "b")
+        ds_scorecard$x_sel_a <- deriveArray(
+            ds_scorecard[c("x1", "x2")], "x mr - a", selections = "a"
+        )
+        ds_scorecard$x_sel_b <- deriveArray(
+            ds_scorecard[c("x1", "x2")], "x mr - b", selections = "b"
+        )
 
         scorecard_cube <- crtabs(~scorecard(x_sel_a, x_sel_b), ds_scorecard)
 

--- a/tests/testthat/test-cubes.R
+++ b/tests/testthat/test-cubes.R
@@ -490,4 +490,25 @@ with_test_authentication({
     test_that("Univariate stats", {
         expect_equivalent(as.array(crtabs(mean(v3) ~ 1, data = ds)), 17.5)
     })
+
+    test_that("scorecard query works", {
+        # Setup a dataset for scorecards
+        ds_scorecard <- newDataset(
+            data.frame(
+                x1 = factor(c("a", "b", "c", "a", "c"), letters[1:3]),
+                x2 = factor(c("c", "c", "b", "c", "b"), letters[1:3])
+            ),
+            "scorecard test"
+        )
+        ds_scorecard$x_sel_a<- deriveArray(ds_scorecard[c("x1", "x2")], "x mr - a", selections = "a")
+        ds_scorecard$x_sel_b<- deriveArray(ds_scorecard[c("x1", "x2")], "x mr - b", selections = "b")
+
+        scorecard_cube <- crtabs(~scorecard(ds_scorecard$x_sel_a, ds_scorecard$x_sel_b), ds_scorecard)
+
+        expect_equal(dimnames(scorecard_cube)[[1]], c("x1", "x2"))
+        expect_equal(dimnames(scorecard_cube)[[2]], c("x mr - a", "x mr - b"))
+        scorecard_values <- as.array(scorecard_cube)
+        dimnames(scorecard_values) <- NULL
+        expect_equal(scorecard_values, matrix(c(2, 0, 1, 2), ncol = 2))
+    })
 })

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -117,4 +117,56 @@ with_mock_crunch({
             )
         )
     })
+
+    test_that("scorecard works", {
+        expect_equal(
+            formulaToQuery(~scorecard(ds$mymrset, selectCategories(ds$catarray, "A"))),
+            list(
+                measures = list(count = list(`function` = "cube_count", args = list())),
+                with = list(
+                    v1 = list(
+                        `function` = "fuse",
+                        args = list(
+                            list(
+                                list(
+                                    `function` = "as_selected",
+                                    args = list(list(variable = self(ds$mymrset)))
+                                ),
+                                list(
+                                    `function` = "as_selected",
+                                    args = list(
+                                        list(
+                                            `function` = "select_categories",
+                                            args = list(
+                                                list(variable = self(ds$catarray)),
+                                                list(value = I("A"))
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+                dimensions = list(list(
+                    list(local = "v1.subvariables"),
+                    list(local = "v1.categories"),
+                    list(local = "v1.variables")
+                ))
+            )
+        )
+
+        expect_error(
+            formulaToQuery(~scorecard(ds$catarray)),
+            "Expected Multiple Response variables or expressions in a scorecard"
+        )
+        expect_error(
+            formulaToQuery(~scorecard(ds$mymrset) + ds$gender),
+            "scorecard queries cannot be combined with other dimensions"
+        )
+        expect_error(
+            formulaToQuery(mean(ds$birthyr) ~ scorecard(ds$mymrset)),
+            "scorecard queries can only have count as the aggregation"
+        )
+    })
 })


### PR DESCRIPTION
Can now do:

```r
slide <- newSlide(deck, ~scorecard(ds$enjoy_mr, ds$another_mr), title = "scorecard slide")
```

I continued to stretch the formula notation, at some point this may break, but for now I think it's nice because it means you can use the scorecard query other places that expect a query too (eg in `crtabs`).

Left to do:
documentation (not sure where to put it)