### PR TITLE
Script dryrun

### DIFF
--- a/R/automation.R
+++ b/R/automation.R
@@ -231,6 +231,11 @@ crunchAutomationErrorHandler <- function(response) {
             }
         )
 
+        # Sometimes no further information is provided
+        if (length(errors) == 0) {
+            halt("Error when running Crunch Automation script, but no futher information is available.") # nocov
+        }
+
         errors <- do.call(
             function(...) rbind(..., stringsAsFactors = FALSE),
             errors

--- a/R/automation.R
+++ b/R/automation.R
@@ -102,6 +102,7 @@ setMethod("scriptSavepoint", "Script", function(x) {
 #' @param is_file The default guesses whether a file or string was
 #' used in the `script` argument, but you can override the heuristics
 #' by specifying `TRUE` for a file, and `FALSE` for a string.
+#' @param ... Additional options, passed on to the API
 #'
 #' @return For `runCrunchAutomation()`: an updated dataset (invisibly),
 #' For `showScriptErrors()`, when run after a failure, a list with two items:
@@ -126,7 +127,7 @@ setMethod("scriptSavepoint", "Script", function(x) {
 #' }
 #' @export
 #' @seealso [`automation-undo`] & [`script-catalog`]
-runCrunchAutomation <- function(dataset, script, is_file = string_is_file_like(script)) {
+runCrunchAutomation <- function(dataset, script, is_file = string_is_file_like(script), ...) {
     reset_automation_error_env()
     stopifnot(is.dataset(dataset))
     stopifnot(is.character(script))
@@ -141,7 +142,7 @@ runCrunchAutomation <- function(dataset, script, is_file = string_is_file_like(s
 
     crPOST(
         shojiURL(dataset, "catalogs", "scripts"),
-        body = toJSON(wrapEntity(body = list(body = script))),
+        body = toJSON(wrapEntity(body = list(body = script, ...))),
         status.handlers = list(`400` = crunchAutomationErrorHandler)
     )
     invisible(refresh(dataset))

--- a/man/runCrunchAutomation.Rd
+++ b/man/runCrunchAutomation.Rd
@@ -5,12 +5,7 @@
 \alias{showScriptErrors}
 \title{Run a crunch automation script}
 \usage{
-runCrunchAutomation(
-  dataset,
-  script,
-  is_file = string_is_file_like(script),
-  ...
-)
+runCrunchAutomation(dataset, script, is_file = NULL, ...)
 
 showScriptErrors()
 }
@@ -18,7 +13,8 @@ showScriptErrors()
 \item{dataset}{A crunch dataset}
 
 \item{script}{A path to a text file with crunch automation syntax
-or a string the syntax loaded in R.}
+or a string the syntax loaded in R. If multiple paths are provided,
+they will be concatenated together and performed as a single script.}
 
 \item{is_file}{The default guesses whether a file or string was
 used in the \code{script} argument, but you can override the heuristics

--- a/man/runCrunchAutomation.Rd
+++ b/man/runCrunchAutomation.Rd
@@ -5,7 +5,12 @@
 \alias{showScriptErrors}
 \title{Run a crunch automation script}
 \usage{
-runCrunchAutomation(dataset, script, is_file = string_is_file_like(script))
+runCrunchAutomation(
+  dataset,
+  script,
+  is_file = string_is_file_like(script),
+  ...
+)
 
 showScriptErrors()
 }
@@ -18,6 +23,8 @@ or a string the syntax loaded in R.}
 \item{is_file}{The default guesses whether a file or string was
 used in the \code{script} argument, but you can override the heuristics
 by specifying \code{TRUE} for a file, and \code{FALSE} for a string.}
+
+\item{...}{Additional options, passed on to the API}
 }
 \value{
 For \code{runCrunchAutomation()}: an updated dataset (invisibly),

--- a/tests/testthat/test-automation.R
+++ b/tests/testthat/test-automation.R
@@ -1,11 +1,28 @@
 context("Automation")
 
-test_that("string_is_file_like behaves", {
-    expect_true(string_is_file_like("test.txt"))
-    expect_true(string_is_file_like("test.crunch"))
-    expect_false(string_is_file_like("RENAME v1 TO age;\nSET EXCLUSION v1 > 21;"))
-    expect_false(string_is_file_like("test1.txt\ntest2.txt"))
-    expect_false(string_is_file_like("test"))
+test_that("strings_are_file_like behaves", {
+    expect_true(strings_are_file_like("test.txt"))
+    expect_true(strings_are_file_like("test.crunch"))
+    expect_false(strings_are_file_like("RENAME v1 TO age;\nSET EXCLUSION v1 > 21;"))
+    expect_false(strings_are_file_like("test1.txt\ntest2.txt"))
+    expect_false(strings_are_file_like("test"))
+    expect_equal(strings_are_file_like(c("test.txt", "test")), c(TRUE, FALSE))
+})
+
+test_that("read_scripts works", {
+    temp1 <- tempfile()
+    writeLines(c("a", "b"), temp1)
+    temp2 <- tempfile()
+    writeLines(c("c", "d"), temp2)
+
+    expect_equal(read_scripts(temp1), list(text = c("a", "b"), file = temp1))
+    expect_equal(
+        read_scripts(c(temp1, temp2)),
+        list(
+            text = c(paste0("# ", temp1), "a", "b", paste0("# ", temp2), "c", "d"),
+            file = NULL
+        )
+    )
 })
 
 with_mock_crunch({


### PR DESCRIPTION
- Allows `...` in `runCrunchAutomatio()` so we can use the `dry` argument (and later `dry_run` when the API is updated)
- Allows passing multiple scripts, which are then concatenated. I think this is particularly important for dry runs because the validation would need to be cumulative.
- I couldn't resist subtracting out the line numbers for multiple scripts, we can undo it if you really want, but I don't think it's that hard to avoid the off by 1 error, and being able to jump right to errors in their original file when running `runCrunchAutomation(list.files(), dry_run = TRUE)` is a huge UX improvement.
<img width="411" alt="Screen Shot 2021-03-23 at 4 18 23 PM" src="https://user-images.githubusercontent.com/2104579/112219726-66074b80-8bf3-11eb-8817-cfa34be598f9.png">
