### PR TITLE
Guard against bad data from API in a folder

### DIFF
--- a/R/variable-folder.R
+++ b/R/variable-folder.R
@@ -25,7 +25,9 @@ setMethod("folderExtraction", "VariableFolder", function(x, tuple) {
     ## "tuple" is a list of length 1, name is URL, contents is the actual tuple
     url <- names(tuple)
     tuple <- tuple[[1]]
-    if (tuple$type == "folder") {
+    if (is.null(tuple$type)) {
+        halt("Could not find type for item in folder: ", url) #nocov
+    } else if (tuple$type == "folder") {
         return(VariableFolder(crGET(url)))
     } else {
         tup <- VariableTuple(entity_url = url, body = tuple, index_url = self(x))

--- a/R/variables.R
+++ b/R/variables.R
@@ -92,5 +92,7 @@ setMethod("variables", "SearchResults", function(x) {
 #' @rdname variables
 #' @export
 setMethod("variables", "VariableFolder", function(x) {
-    x[!(types(x) %in% "folder")]
+    types <- types(x)
+    # `is.na` to guard against objects in folders that are missing the type
+    x[!is.na(types) & !(types %in% "folder")]
 })


### PR DESCRIPTION
I believe this fixes a cryptic bug that a user experienced. I the API returned a folder in the private/secure folder had an object with no type and so when trying to get the variables of a dataset, this line was a length 0 in an `if` statement:
https://github.com/Crunch-io/rcrunch/blob/095d861434d9329ac0e5f3890b67a2adc07be171/R/variable-folder.R#L30

Error was: 
```
Error in h(simpleError(msg, call)) : 
  error in evaluating the argument 'table' in selecting a method for function '%in%': error in evaluating the argument 'x' in selecting a method for function 'variables': argument is of length zero
```