### PR TITLE
reconcile slide queries from rcrunch with whaam behavior

### DIFF
--- a/tests/testthat/test-decks.R
+++ b/tests/testthat/test-decks.R
@@ -325,6 +325,17 @@ with_mock_crunch({
         )
     })
 
+    test_that("New slide - prevents categories in first dim", {
+        expect_error(
+            newSlide(
+                main_deck,
+                ~categories(catarray) + subvariables(catarray) + mymrset,
+                title = "Title"
+            ),
+            "First dimension of .+ analysis cannot be .+ categories"
+        )
+    })
+
     slide <- main_deck[[1]]
     test_that("Slide show method", {
         expect_prints(

--- a/tests/testthat/test-formula.R
+++ b/tests/testthat/test-formula.R
@@ -33,6 +33,25 @@ with_mock_crunch({
         expect_equal(ftq_with_data, ftq_without_data)
     })
 
+    test_that("formulaToQuery expands dimensions for as_selected expressions", {
+        expect_equal(
+            formulaToQuery(~selectCategories(ds$catarray, 1)),
+            list(
+                dimensions = list(list(
+                    list(
+                        `function` = "dimension",
+                        args = list(
+                            unclass(zcl(selectCategories(ds$catarray, 1))),
+                            unclass(zcl("subvariables"))
+                        )
+                    ),
+                    unclass(zcl(selectCategories(ds$catarray, 1)))
+                )),
+                measures = list(count = list(`function` = "cube_count", args = list()))
+            )
+        )
+    })
+
     test_that("registerCubeFunctions work within formulaToQuery - mean", {
         expect_equal(
             formulaToQuery(mean(ds$birthyr)~1),

--- a/vignettes/deck-cookbook.Rmd
+++ b/vignettes/deck-cookbook.Rmd
@@ -242,6 +242,26 @@ slide <- newSlide(
 )
 ```
 
+The "categories" dimension cannot be the first dimension (used in the "tabs" of the analysis in
+a Crunch Dashboard) of a slide analysis that has 3 dimensions. Instead, to get the "tabs" dimension
+have the categorical array variable, choose one category to select, and create a Multiple Response
+variable out of it.
+
+When trying to make a slide with a categorical array (`ca`) and another variables(`cat`), the 
+following table shows the 6 queries that are valid and which dimension the web app will
+display on each of the "rows", "columns" and "tabs" dimensions. Here we have chosen to select
+the category with name = `"category"` when using `selectCategories`, but any valid category id
+or name could be used instead.
+
+| query                                    | rows            | columns         | tabs            |
+|------------------------------------------|-----------------|-----------------|-----------------|
+|`~cat + categories(ca) + subvariables(ca)`| CA categories   | CA subvariables | other variable  |
+|`~cat + subvariables(ca) + categories(ca)`| CA subvariables | CA categories   | other variable  |
+|`~subvariables(ca) + categories(ca) + cat`| CA categories   | other variable  | CA subvariables |
+|`~subvariables(ca) + cat + categories(ca)`| other variable  | CA categories   | CA subvariables |
+|`~cat + selectCategories(ca, "category")` | other variable  | CA subvariables | CA categories   |
+|`~selectCategories(ca, "category") + cat` | CA subvariables | other variable  | CA categories   |
+
 
 ### Mean of a Numeric variable
 #### Problem


### PR DESCRIPTION
block array categories dimension in first dimension of a slide's analysis because whaam chokes on it

allow `selectCategories()` in the query so users can convert cat arrays into MRs like whaam does