### PR TITLE
message progress url options

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -102,15 +102,23 @@ handleAPIsuccess <- function(code, response) {
             progress_url <- handleShoji(content(response))
             ## Quick validation
             if (is.character(progress_url) && length(progress_url) == 1) {
-                tryCatch(pollProgress(progress_url, getOption("crunch.poll.wait", 0.5)),
-                         error = function(e) {
-                             ## Handle the error here so we can message the
-                             ## Location header, if present
-                             if (!is.null(loc)) {
-                                 message("Result URL: ", loc)
-                             }
-                             stop(e)
-                         }
+                if (getOption("crunch.show.progress.url", FALSE)) {
+                    message(paste0("Checking progress at: ", progress_url))
+                }
+                tryCatch(
+                    pollProgress(progress_url, getOption("crunch.poll.wait", 0.5)),
+                    error = function(e) {
+                        message(paste0(
+                            "Something went wrong during `pollProgress()` of url: ",
+                            progress_url
+                        ))
+                        ## Handle the error here so we can message the
+                        ## Location header, if present
+                        if (!is.null(loc)) {
+                            message("Result URL: ", loc)
+                        }
+                        stop(e)
+                    }
                 )
             }
         }

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -124,6 +124,17 @@ with_mock_crunch({
                 sub("\\.json$", "", logs$url),
                 c("app.crunch.io/api/progress2/1", "app.crunch.io/api/progress2/2")
             )
+        }),
+        test_that("'crunch.show.progress.url' option works", {
+            counter <<- 1
+            with(temp.option(crunch.poll.wait = 0.01, "crunch.show.progress.url" = TRUE), {
+                expect_message(
+                    capture.output(handleAPIresponse(
+                        fakeProg("https://app.crunch.io/api/progress/")
+                    )),
+                    "Checking progress at: https://app.crunch.io/api/progress/"
+                )
+            })
         })
     )
 })


### PR DESCRIPTION
I saw this may not address the problem we're currently facing, but I think this is still worth it:

Now if there's an error during `pollProgress()` it will message the progress url. 

Also added option `crunch.show.progress.url`, which always messages it. I'm not sure it's super useful, but will give us this capability in the future.