### PR TITLE
[#178181135]: better check for empty values in catalog

### DIFF
--- a/R/shoji-catalog.R
+++ b/R/shoji-catalog.R
@@ -323,7 +323,9 @@ catalogToDataFrame <- function(x, keys = TRUE, rownames = NULL,
         for (i in seq_along(entry_list)) {
             for (j in names(entry_list[[i]])) {
                 val <- entry_list[[i]][[j]]
-                if (identical(val, list())) {
+                # By checking if identical to unnamed list we replace  JSON `[]` and
+                # `{}` with NAs but not `NULL` so that bad keys still get right error
+                if (identical(unname(val), list())) {
                     val <- NA
                 }
                 out[[j]][i] <- val


### PR DESCRIPTION
Fixes a bug where we couldn't print a deck catalog because it's `dashboard` key was an empty JSON dict.

```r
x <- jsonlite::fromJSON("{}")

identical(x, list())
#> FALSE

identical(unname(x), list())
#> TRUE
```