### PR TITLE
[181049738]: copyFolders uses public folder not root

### DIFF
--- a/R/folders.R
+++ b/R/folders.R
@@ -333,7 +333,7 @@ folder_recurse <- function(folder) {
 }
 
 # take a folder/var tree (from folder_recurse) and copy it to dataset
-plant_tree <- function(tree, dataset, folder_position = rootVariableFolder(dataset)) {
+plant_tree <- function(tree, dataset, folder_position) {
     lapply(seq_along(tree), function(i) {
         item <- tree[[i]]
         if(!is.null(names(item))) {
@@ -379,8 +379,9 @@ copyFolders <- function(source, target) {
     if (!is.dataset(source) | !is.dataset(target)) {
         halt("Both source and target must be Crunch datasets.")
     }
-    source_tree <- folder_recurse(rootVariableFolder(source))
-    plant_tree(list(source_tree), target)
+    source_tree <- folder_recurse(publicFolder(source))
+    plant_tree(list(source_tree), target, publicFolder(target))
+
     return(invisible(refresh(target)))
 }
 

--- a/R/hide-variables.R
+++ b/R/hide-variables.R
@@ -38,7 +38,16 @@ NULL
     # are available to all
     api_must_work <- type != "private"
 
-    url <- shojiURL(rootVariableFolder(x), "catalogs", api_type, mustWork = api_must_work)
+    # Get root variables folder (which contains the first levels inside of it
+    # but isn't really used directly). NB can't use `rootFolder()` because
+    # it goes to the folder that contains the dataset, not the root variables
+    # folder.
+    if (!is.dataset(x)) {
+        x <- ShojiEntity(crGET(datasetReference(x)))
+    }
+    root <- VariableFolder(crGET(shojiURL(x, "catalogs", "folders")))
+
+    url <- shojiURL(root, "catalogs", api_type, mustWork = api_must_work)
     if (is.null(url)) return(url)
 
     VariableFolder(crGET(url))

--- a/R/variable-folder.R
+++ b/R/variable-folder.R
@@ -1,14 +1,3 @@
-rootVariableFolder <- function(x) {
-    # This function exists because the generic rootFolder() for a dataset would
-    # get the root project folder, i.e. the root for moving it.
-    # This function gives you the root variable folder for a dataset or thing
-    # contained in a dataset.
-    if (!is.dataset(x)) {
-        x <- ShojiEntity(crGET(datasetReference(x)))
-    }
-    return(VariableFolder(crGET(shojiURL(x, "catalogs", "folders"))))
-}
-
 #' @rdname describe-entity
 #' @export
 setMethod(


### PR DESCRIPTION
Missed a place where we relied on the old style of public variables in the root of the variables directory instead of using the public folder.

I also inlined the logic of `rootVariableFolder()` because I don't think we ever want to use it directly so we can avoid these bugs.