### PR TITLE
[183690868]: equal instead of identical on data.frame check

### DIFF
--- a/tests/testthat/test-as-data-frame.R
+++ b/tests/testthat/test-as-data-frame.R
@@ -112,7 +112,7 @@ with_mock_crunch({
         # test local CDF variables
         cdf$newvar <- expected$newvar <- c(1:209, NA)
 
-        expect_identical(csvToDataFrame(csv_df, cdf), expected)
+        expect_equal(csvToDataFrame(csv_df, cdf), expected)
     })
 
     test_that("csvToDataFrame respects include.hidden", {
@@ -122,7 +122,7 @@ with_mock_crunch({
         cdf <- as.data.frame(ds, include.hidden = FALSE)
         actual <- csvToDataFrame(csv_df, cdf)
         actual <- actual[, !grepl("^funnel", names(actual))] # funnel vars added after test added
-        expect_identical(actual, expected)
+        expect_equal(actual, expected)
     })
 
     test_that("as.data.frame when a variable has an apostrophe in its alias", {


### PR DESCRIPTION
Not exactly sure what's up, but it's platform dependent, so I'm not super interested in figuring it out.