### PR TITLE
Fix the ordering of the code snippets so that it matches the text

### DIFF
--- a/vignettes/variable-order.Rmd
+++ b/vignettes/variable-order.Rmd
@@ -153,11 +153,7 @@ Folders themselves have names, which we can set with `setName()`:
 ```r
 ds %>%
     cd("Demos") %>%
-    setNames(c("Birth Year", "Gender", "Political Ideo. (3 category)",
-    "Political Ideo. (7 category)",  "Political Ideo. (7 category; other)",  
-    "Race", "Education", "Marital Status", "Phone", "Family Income", "Region",
-    "State", "Weight", "Voter Registration (new)", "Is a voter?",
-    "Voter Registration (old)", "Voter Registration"))
+    setName("Demographics")
 ```
 
 We can also set the names of the objects contained in a folder with `setNames()`:
@@ -165,7 +161,11 @@ We can also set the names of the objects contained in a folder with `setNames()`
 ```r
 ds %>%
     cd("Demos") %>%
-    setName("Demographics")
+    setNames(c("Birth Year", "Gender", "Political Ideo. (3 category)",
+    "Political Ideo. (7 category)",  "Political Ideo. (7 category; other)",  
+    "Race", "Education", "Marital Status", "Phone", "Family Income", "Region",
+    "State", "Weight", "Voter Registration (new)", "Is a voter?",
+    "Voter Registration (old)", "Voter Registration"))
 ```
 
 ## Ordering within folders


### PR DESCRIPTION
Vignette:

[Variable Folders and Organization](https://cran.r-project.org/web/packages/crunch/vignettes/variable-order.html)

Section:

Renaming folders and folder contents