### PR TITLE
Script catalog print 184616983

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
 VignetteBuilder: knitr
 Language: en-US
 Encoding: UTF-8
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 LazyData: true
 Collate:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # crunch 1.30.2 (Development version)
+* Fix for printing `ScriptCatalog` (and removal of the `ScriptCatalog` method for
+  `ScriptBody` the full body, subset to the particular script if you need the body
+  text with `vapply(scripts(ds), function(x) scriptBody(x), character(1))`).
 
 # crunch 1.30.1
 * Fixes for problems found with R-devel found by CRAN checks.

--- a/R/automation.R
+++ b/R/automation.R
@@ -43,11 +43,6 @@ setMethod("timestamps", "Script", function(x) {
 
 #' @rdname describe-catalog
 #' @export
-setMethod("scriptBody", "ScriptCatalog", function(x) {
-    return(getIndexSlot(x, "body"))
-})
-#' @rdname describe-catalog
-#' @export
 setMethod("scriptBody", "Script", function(x) {
     return(x@body$body)
 })

--- a/R/show.R
+++ b/R/show.R
@@ -215,8 +215,7 @@ formatVersionCatalog <- function(x, from = Sys.time()) {
 formatScriptCatalog <- function(x, from = Sys.time(), body_width = 20) {
     ts <- timestamps(x)
     ts <- .ts_format(ts, from)
-
-    scriptBody <- vapply(scriptBody(x), function(script) {
+    scriptBody <- vapply(getIndexSlot(x, "body_excerpt"), function(script) {
         if (nchar(script) > body_width) {
             paste0(strtrim(script, max(body_width - 3, 0)), "...")
         } else {
@@ -226,6 +225,8 @@ formatScriptCatalog <- function(x, from = Sys.time(), body_width = 20) {
 
     return(data.frame(
         Timestamp = ts,
+        mutations = getIndexSlot(x, "mutations", logical(1), NA),
+        items_created = getIndexSlot(x, "items_created", numeric(1), NA_real_),
         scriptBody = scriptBody,
         stringsAsFactors = FALSE,
         row.names = NULL

--- a/man/describe-catalog.Rd
+++ b/man/describe-catalog.Rd
@@ -28,7 +28,6 @@
 \alias{ids,AbstractCategories-method}
 \alias{timestamps,ScriptCatalog-method}
 \alias{timestamps,Script-method}
-\alias{scriptBody,ScriptCatalog-method}
 \alias{scriptBody,Script-method}
 \alias{names,BatchCatalog-method}
 \alias{ids<-,Categories-method}
@@ -115,8 +114,6 @@ dates(x) <- value
 \S4method{timestamps}{ScriptCatalog}(x)
 
 \S4method{timestamps}{Script}(x)
-
-\S4method{scriptBody}{ScriptCatalog}(x)
 
 \S4method{scriptBody}{Script}(x)
 

--- a/mocks/app.crunch.io/api/datasets/1/scripts.json
+++ b/mocks/app.crunch.io/api/datasets/1/scripts.json
@@ -3,8 +3,10 @@
     "self": "https://app.crunch.io/api/datasets/1/scripts/",
     "index": {
         "https://app.crunch.io/api/datasets/1/scripts/3cb2fb/": {
-            "body": "RENAME starttime TO interviewtime; \nSET EXCLUSION birthyr > 2000;",
-            "creation_time": "2020-05-06T17:36:27.238000+00:00"
+            "body_excerpt": "RENAME starttime TO interviewtime; \nSET EXCLUSION birthyr > 2000;",
+            "creation_time": "2020-05-06T17:36:27.238000+00:00",
+            "mutations": true,
+            "items_created": 0
         }
     }
 }

--- a/tests/testthat/test-automation.R
+++ b/tests/testthat/test-automation.R
@@ -77,7 +77,6 @@ with_mock_crunch({
             timestamps(ds_scripts),
             as.POSIXlt("2020-05-06 17:36:27.237 UTC", tz = "UTC")
         )
-        expect_equal(scriptBody(ds_scripts), script_text)
         # On single script
         expect_is(ds_scripts[[1]], "Script")
         expect_true(is.script(ds_scripts[[1]]))
@@ -102,6 +101,8 @@ with_mock_crunch({
             formatted,
             data.frame(
                 Timestamp = c("2 days ago"),
+                mutations = TRUE,
+                items_created = 0,
                 scriptBody = paste0(strtrim(script_text, 7), "..."),
                 stringsAsFactors = FALSE
             )


### PR DESCRIPTION
At some point, the scripts catalog changed from having the full script body to only an excerpt. Because the automation commands are only tested with fixtures (and these fixtures were manually created), they were updated manually.

I also added to the print method, details about the `mutations` and `items_created`, because this seems useful.