### PR TITLE
Variables cache fixes 184826032

### DIFF
--- a/R/dataset-extract.R
+++ b/R/dataset-extract.R
@@ -149,14 +149,15 @@ setMethod("[[", c("CrunchDataset", "character"), function(x, i, ..., drop = FALS
     if (!is.null(out)) {
         out <- CrunchVariable(out, filter = activeFilter(x))
         if (
-            alias(out) %in% hiddenVariables(x, "alias") &&
-            envOrOption("crunch.warn.hidden", TRUE, expect_lgl = TRUE)
+            envOrOption("crunch.warn.hidden", TRUE, expect_lgl = TRUE) &&
+            alias(out) %in% hiddenVariables(x, "alias")
         ) {
             warning("Variable ", alias(out), " is hidden", call. = FALSE)
         }
         if (
-            alias(out) %in% privateVariables(x, "alias") &&
             envOrOption("crunch.warn.private", TRUE, expect_lgl = TRUE)
+            && alias(out) %in% privateVariables(x, "alias")
+
         ) {
             warning("Variable ", alias(out), " is private", call. = FALSE)
         }

--- a/R/dataset.R
+++ b/R/dataset.R
@@ -361,10 +361,11 @@ namekey <- function(x = NULL) {
 #' @rdname describe-catalog
 #' @export
 setMethod("names", "CrunchDataset", function(x) {
-    if (envOrOption("crunch.exclude.hidden.private", TRUE, expect_lgl = TRUE)) {
-        vars <- variables(x)
-    } else {
+    opt_name <- "crunch.names.includes.hidden.private.variables"
+    if (envOrOption(opt_name, FALSE, expect_lgl = TRUE)) {
         vars <- allVariables(x)
+    } else {
+        vars <- variables(x)
     }
     getIndexSlot(vars, namekey(x))
 })

--- a/R/dataset.R
+++ b/R/dataset.R
@@ -361,7 +361,12 @@ namekey <- function(x = NULL) {
 #' @rdname describe-catalog
 #' @export
 setMethod("names", "CrunchDataset", function(x) {
-    getIndexSlot(variables(x), namekey(x))
+    if (envOrOption("crunch.exclude.hidden.private", TRUE, expect_lgl = TRUE)) {
+        vars <- variables(x)
+    } else {
+        vars <- allVariables(x)
+    }
+    getIndexSlot(vars, namekey(x))
 })
 
 setMethod("tuple", "CrunchDataset", function(x) x@tuple)

--- a/R/misc.R
+++ b/R/misc.R
@@ -210,6 +210,7 @@ vectorOrList <- function(obj, type) {
 #' | crunch.warn.hidden           | R_CRUNCH_WARN_HIDDEN           | TRUE          | Whether to warn when using a hidden variable                                |
 #' | crunch.warn.private          | R_CRUNCH_WARN_PRIVATE          | TRUE          | Whether to warn when using a private variable                               |
 #' | crunch.names.includes.hidden.private.variables | R_NAMES_INCLUDES_HIDDEN_PRIVATE_VARIABLES| TRUE | Whether to include hidden/private variables from names(ds) |
+#' | crunch.order.var.catalog     | R_CRUNCH_ORDER_VAR_CATALOG     | TRUE          | Whether to set the variable catalog in the order of the hierarchical order  |
 #' | crunch.delimiter             | R_CRUNCH_DELIMITER             | "/"           | What to use as a delimiter when printing folder paths                       |
 #' | crunch.check.updates         | R_CRUNCH_CHECK_UPDATES         | TRUE          | Whether to check for updates to the crunch package                          |
 #' | crunch.debug                 | R_CRUNCH_DEBUG                 | FALSE         | Whether to print verbose information for debugging                          |

--- a/R/misc.R
+++ b/R/misc.R
@@ -209,6 +209,7 @@ vectorOrList <- function(obj, type) {
 #' | crunch.require.confirmation  | R_CRUNCH_REQUIRE_CONFIRMATION  | TRUE          | Whether to require confirmation for destructive actions (like [`delete()`]) |
 #' | crunch.warn.hidden           | R_CRUNCH_WARN_HIDDEN           | TRUE          | Whether to warn when using a hidden variable                                |
 #' | crunch.warn.private          | R_CRUNCH_WARN_PRIVATE          | TRUE          | Whether to warn when using a private variable                               |
+#' | crunch.exclude.hidden.private| R_CRUNCH_EXCLUDE_HIDDEN_PRIVATE| TRUE          | Whether to exclude hidden/private variables from names(ds)                  |
 #' | crunch.delimiter             | R_CRUNCH_DELIMITER             | "/"           | What to use as a delimiter when printing folder paths                       |
 #' | crunch.check.updates         | R_CRUNCH_CHECK_UPDATES         | TRUE          | Whether to check for updates to the crunch package                          |
 #' | crunch.debug                 | R_CRUNCH_DEBUG                 | FALSE         | Whether to print verbose information for debugging                          |

--- a/R/misc.R
+++ b/R/misc.R
@@ -209,7 +209,7 @@ vectorOrList <- function(obj, type) {
 #' | crunch.require.confirmation  | R_CRUNCH_REQUIRE_CONFIRMATION  | TRUE          | Whether to require confirmation for destructive actions (like [`delete()`]) |
 #' | crunch.warn.hidden           | R_CRUNCH_WARN_HIDDEN           | TRUE          | Whether to warn when using a hidden variable                                |
 #' | crunch.warn.private          | R_CRUNCH_WARN_PRIVATE          | TRUE          | Whether to warn when using a private variable                               |
-#' | crunch.exclude.hidden.private| R_CRUNCH_EXCLUDE_HIDDEN_PRIVATE| TRUE          | Whether to exclude hidden/private variables from names(ds)                  |
+#' | crunch.names.includes.hidden.private.variables | R_NAMES_INCLUDES_HIDDEN_PRIVATE_VARIABLES| TRUE | Whether to include hidden/private variables from names(ds) |
 #' | crunch.delimiter             | R_CRUNCH_DELIMITER             | "/"           | What to use as a delimiter when printing folder paths                       |
 #' | crunch.check.updates         | R_CRUNCH_CHECK_UPDATES         | TRUE          | Whether to check for updates to the crunch package                          |
 #' | crunch.debug                 | R_CRUNCH_DEBUG                 | FALSE         | Whether to print verbose information for debugging                          |

--- a/R/variable-catalog.R
+++ b/R/variable-catalog.R
@@ -1,7 +1,7 @@
 setMethod("initialize", "VariableCatalog", function(.Object, ...) {
     .Object <- callNextMethod(.Object, ...)
     h_url <- .Object@orders$hier
-    if (!is.null(h_url)) {
+    if (!is.null(h_url) && envOrOption("crunch.order.var.catalog", TRUE, expect_lgl = TRUE)) {
         o <- crGET(h_url, query = list(relative = "on"))
         .Object@order <- VariableOrder(o)
         ## Sort catalog based on the order, but be forgiving if the order isn't

--- a/man/envOrOption.Rd
+++ b/man/envOrOption.Rd
@@ -50,6 +50,7 @@ the option name is in all capital letters, with "." replaced with
    crunch.warn.hidden \tab R_CRUNCH_WARN_HIDDEN \tab TRUE \tab Whether to warn when using a hidden variable \cr
    crunch.warn.private \tab R_CRUNCH_WARN_PRIVATE \tab TRUE \tab Whether to warn when using a private variable \cr
    crunch.names.includes.hidden.private.variables \tab R_NAMES_INCLUDES_HIDDEN_PRIVATE_VARIABLES \tab TRUE \tab Whether to include hidden/private variables from names(ds) \cr
+   crunch.order.var.catalog \tab R_CRUNCH_ORDER_VAR_CATALOG \tab TRUE \tab Whether to set the variable catalog in the order of the hierarchical order \cr
    crunch.delimiter \tab R_CRUNCH_DELIMITER \tab "/" \tab What to use as a delimiter when printing folder paths \cr
    crunch.check.updates \tab R_CRUNCH_CHECK_UPDATES \tab TRUE \tab Whether to check for updates to the crunch package \cr
    crunch.debug \tab R_CRUNCH_DEBUG \tab FALSE \tab Whether to print verbose information for debugging \cr

--- a/man/envOrOption.Rd
+++ b/man/envOrOption.Rd
@@ -49,7 +49,7 @@ the option name is in all capital letters, with "." replaced with
    crunch.require.confirmation \tab R_CRUNCH_REQUIRE_CONFIRMATION \tab TRUE \tab Whether to require confirmation for destructive actions (like \code{\link[=delete]{delete()}}) \cr
    crunch.warn.hidden \tab R_CRUNCH_WARN_HIDDEN \tab TRUE \tab Whether to warn when using a hidden variable \cr
    crunch.warn.private \tab R_CRUNCH_WARN_PRIVATE \tab TRUE \tab Whether to warn when using a private variable \cr
-   crunch.exclude.hidden.private \tab R_CRUNCH_EXCLUDE_HIDDEN_PRIVATE \tab TRUE \tab Whether to exclude hidden/private variables from names(ds) \cr
+   crunch.names.includes.hidden.private.variables \tab R_NAMES_INCLUDES_HIDDEN_PRIVATE_VARIABLES \tab TRUE \tab Whether to include hidden/private variables from names(ds) \cr
    crunch.delimiter \tab R_CRUNCH_DELIMITER \tab "/" \tab What to use as a delimiter when printing folder paths \cr
    crunch.check.updates \tab R_CRUNCH_CHECK_UPDATES \tab TRUE \tab Whether to check for updates to the crunch package \cr
    crunch.debug \tab R_CRUNCH_DEBUG \tab FALSE \tab Whether to print verbose information for debugging \cr

--- a/man/envOrOption.Rd
+++ b/man/envOrOption.Rd
@@ -49,6 +49,7 @@ the option name is in all capital letters, with "." replaced with
    crunch.require.confirmation \tab R_CRUNCH_REQUIRE_CONFIRMATION \tab TRUE \tab Whether to require confirmation for destructive actions (like \code{\link[=delete]{delete()}}) \cr
    crunch.warn.hidden \tab R_CRUNCH_WARN_HIDDEN \tab TRUE \tab Whether to warn when using a hidden variable \cr
    crunch.warn.private \tab R_CRUNCH_WARN_PRIVATE \tab TRUE \tab Whether to warn when using a private variable \cr
+   crunch.exclude.hidden.private \tab R_CRUNCH_EXCLUDE_HIDDEN_PRIVATE \tab TRUE \tab Whether to exclude hidden/private variables from names(ds) \cr
    crunch.delimiter \tab R_CRUNCH_DELIMITER \tab "/" \tab What to use as a delimiter when printing folder paths \cr
    crunch.check.updates \tab R_CRUNCH_CHECK_UPDATES \tab TRUE \tab Whether to check for updates to the crunch package \cr
    crunch.debug \tab R_CRUNCH_DEBUG \tab FALSE \tab Whether to print verbose information for debugging \cr

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -25,7 +25,7 @@ crunch:::set_crunch_opts(
     crunch.namekey.dataset = "alias",
     crunch.namekey.array = "alias",
     crunch.already.shown.folders.msg = TRUE,
-    crunch.exclude.hidden.private = TRUE
+    crunch.names.includes.hidden.private.variables = FALSE
 )
 
 options(

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -24,7 +24,8 @@ crunch:::set_crunch_opts(
     crunch.check.updates = FALSE,
     crunch.namekey.dataset = "alias",
     crunch.namekey.array = "alias",
-    crunch.already.shown.folders.msg = TRUE
+    crunch.already.shown.folders.msg = TRUE,
+    crunch.exclude.hidden.private = TRUE
 )
 
 options(

--- a/tests/testthat/test-dataset-entity.R
+++ b/tests/testthat/test-dataset-entity.R
@@ -292,11 +292,12 @@ if (tolower(Sys.info()[["sysname"]]) != "windows") {
             })
         })
 
-        test_that("crunch.exclude.hidden.private affects names()", {
+        test_that("crunch.names.includes.hidden.private.variables affects names()", {
+            opt_name <- "crunch.names.includes.hidden.private.variables"
             ds_econ <- cachedLoadDataset("ECON.sav")  # --- Has hidden variables
-            expect_identical(envOrOption("crunch.exclude.hidden.private"), TRUE)
+            expect_identical(envOrOption(opt_name), FALSE)
             expect_identical(names(ds_econ), aliases(variables(ds_econ)))
-            with(temp.option(crunch = list(crunch.exclude.hidden.private = FALSE)), {
+            with(temp.option(crunch = setNames(list(TRUE), opt_name)), {
                 expect_identical(names(ds_econ), aliases(allVariables(ds_econ)))
             })
             expect_false(identical(aliases(variables(ds_econ)), aliases(allVariables(ds_econ))))

--- a/tests/testthat/test-dataset-entity.R
+++ b/tests/testthat/test-dataset-entity.R
@@ -285,11 +285,21 @@ if (tolower(Sys.info()[["sysname"]]) != "windows") {
         })
 
         test_that("namekey function exists and affects names()", {
-            expect_identical(getOption("crunch.namekey.dataset"), "alias")
+            expect_identical(envOrOption("crunch.namekey.dataset"), "alias")
             expect_identical(names(ds), aliases(variables(ds)))
             with(temp.option(crunch = list(crunch.namekey.dataset = "name")), {
                 expect_identical(names(ds), names(variables(ds)))
             })
+        })
+
+        test_that("crunch.exclude.hidden.private affects names()", {
+            ds_econ <- cachedLoadDataset("ECON.sav")  # --- Has hidden variables
+            expect_identical(envOrOption("crunch.exclude.hidden.private"), TRUE)
+            expect_identical(names(ds_econ), aliases(variables(ds_econ)))
+            with(temp.option(crunch = list(crunch.exclude.hidden.private = FALSE)), {
+                expect_identical(names(ds_econ), aliases(allVariables(ds_econ)))
+            })
+            expect_false(identical(aliases(variables(ds_econ)), aliases(allVariables(ds_econ))))
         })
 
         test_that("Dataset ncol doesn't make any requests if variables have been forced", {


### PR DESCRIPTION
Allows users to opt out of some performance problems introduced by the lazy variables catalog.

For context @sluga, early on when I started at crunch, the main variables catalog contained whether each variable was hidden or not. When we added "private" (aka "secure" variables according to the API, though Mike hates this word), we switched to having to navigate the hidden/private variable folder hierarchy to figure out which variables were hidden or private.

This PR:
1. Checks if user wants to get warnings about hidden/private variables before actually checking if the variable is hidden/private so that basic variable access does not require traversing the hidden/private folders. See below for a reprex.
2. Adds a new option `crunch.exclude.hidden.private` that when set to FALSE (not the default), includes hidden/private variables in `names(ds)`. This fixes weird behavior because RStudio's autocompletion uses `names()` when it detects the user `ds$`, so RStudio users have weird stuttering with datasets with non-trivial hidden/private variable folder structures.

I think that 1. is an unambiguous win, I hadn't realized how easy it would be to fix, I thought these 2 problems were more entangled and so didn't realize I could fix it without messing with names. I believe that using this update version of rcrunch, will allow the rankinator to set `set_crunch_opts(crunch.warn.hidden = FALSE, crunch.warn.private=FALSE)` and then many operations will go from taking ~10 seconds to ~2. I kind of wonder if it should be the new default.

I'm less sure about 2. It seems like a big change to me, but performance about hidden/private variables has been a real issue since rcrunch stopped using the variables catalog for it, and maybe the answer is that R users don't have easy differentiation on variable types.

## Before this PR

Any action with a variable ends up loading the hidden & private variable catalogs even if you've turned off warnings about hidden and private variables.

``` r
suppressPackageStartupMessages(library(crunch))
setupCrunchAuth("team")
httpcache::clearCache()
ds <- loadDataset("Vegetables example - used")
#> Connecting to https://team.crunch.io/api/ with key set using `setupCrunchAuth('team')`.

httpcache::startLog()
set_crunch_opts(crunch.warn.hidden = FALSE, crunch.warn.private = FALSE)
ds$healthy_eater
#> 2023-03-29T15:03:09.850 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?relative=on 200 3570 0 0 0 0 0.19 0.191
#> 2023-03-29T15:03:09.850 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?QUERY=4fd71abbd587e0265a5bd7ad5324208b
#> 2023-03-29T15:03:10.035 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/hier/?relative=on 200 1234 0 0 0 0 0.17 0.17
#> 2023-03-29T15:03:10.035 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/hier/?QUERY=4fd71abbd587e0265a5bd7ad5324208b
#> 2023-03-29T15:03:10.102 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?VariableCatalog&QUERY=4fd71abbd587e0265a5bd7ad5324208b
#> 2023-03-29T15:03:10.102 CACHE HIT https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?VariableCatalog&QUERY=4fd71abbd587e0265a5bd7ad5324208b
#> 2023-03-29T15:03:10.282 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/ 200 349 0 0 0 0 0.165 0.165
#> 2023-03-29T15:03:10.282 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/
#> 2023-03-29T15:03:10.467 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/hidden/ 200 965 0 0 0 0 0.173 0.174
#> 2023-03-29T15:03:10.468 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/hidden/
#> 2023-03-29T15:03:10.650 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/61d7c1624044447abcc0f678140a9225/ 200 221 0 0 0 0 0.155 0.155
#> 2023-03-29T15:03:10.650 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/61d7c1624044447abcc0f678140a9225/
#> 2023-03-29T15:03:10.826 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/ef667cdec445416fb55c4f4563342b19/ 200 364 0 0 0 0 0.165 0.165
#> 2023-03-29T15:03:10.826 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/ef667cdec445416fb55c4f4563342b19/
#> 2023-03-29T15:03:10.833 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?HiddenVariableCatalog
#> 2023-03-29T15:03:10.835 CACHE HIT https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/
#> 2023-03-29T15:03:11.001 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/secure/ 200 314 0 0 0 0 0.158 0.158
#> 2023-03-29T15:03:11.001 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/folders/secure/
#> 2023-03-29T15:03:11.006 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?PrivateVariableCatalog
#> Healthy Eater (categorical)
#> Healthy Eater
#> 
#> 2023-03-29T15:03:11.201 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/cube/?query=%7B%22dimensions%22%3A%5B%7B%22variable%22%3A%22https%3A%2F%2Fteam.crunch.io%2Fapi%2Fdatasets%2F8e6c08d6a6d4409fb3b13019d72ca258%2Fvariables%2F6EkcLwFh05QFY6O4lnGSok000004%2F%22%7D%5D%2C%22measures%22%3A%7B%22count%22%3A%7B%22function%22%3A%22cube_count%22%2C%22args%22%3A%5B%5D%7D%7D%7D&filter=%7B%7D 200 815 0 0 0 0 0.18 0.18
#> 2023-03-29T15:03:11.201 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/cube/?QUERY=e6711b4ae7ce0e20ba9cb4c6765eab1e
#>     Count
#> Yes   120
#> No     85
```

## After this PR

Turning off the warnings about hidden and secure variables avoids navigating the hidden & private folder hierarchies.

``` r
suppressPackageStartupMessages(library(crunch))
setupCrunchAuth("team")
httpcache::clearCache()
ds <- loadDataset("Vegetables example - used")
#> Connecting to https://team.crunch.io/api/ with key set using `setupCrunchAuth('team')`.

httpcache::startLog()
set_crunch_opts(crunch.warn.hidden = FALSE, crunch.warn.private = FALSE)
ds$healthy_eater
#> 2023-03-29T15:05:36.290 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?relative=on 200 3570 0 0 0 0 0.181 0.181
#> 2023-03-29T15:05:36.291 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?QUERY=4fd71abbd587e0265a5bd7ad5324208b
#> 2023-03-29T15:05:36.482 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/hier/?relative=on 200 1234 0 0 0 0 0.178 0.178
#> 2023-03-29T15:05:36.482 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/hier/?QUERY=4fd71abbd587e0265a5bd7ad5324208b
#> 2023-03-29T15:05:36.543 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?VariableCatalog&QUERY=4fd71abbd587e0265a5bd7ad5324208b
#> 2023-03-29T15:05:36.544 CACHE HIT https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/variables/?VariableCatalog&QUERY=4fd71abbd587e0265a5bd7ad5324208b
#> Healthy Eater (categorical)
#> Healthy Eater
#> 
#> 2023-03-29T15:05:36.734 HTTP GET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/cube/?query=%7B%22dimensions%22%3A%5B%7B%22variable%22%3A%22https%3A%2F%2Fteam.crunch.io%2Fapi%2Fdatasets%2F8e6c08d6a6d4409fb3b13019d72ca258%2Fvariables%2F6EkcLwFh05QFY6O4lnGSok000004%2F%22%7D%5D%2C%22measures%22%3A%7B%22count%22%3A%7B%22function%22%3A%22cube_count%22%2C%22args%22%3A%5B%5D%7D%7D%7D&filter=%7B%7D 200 815 0 0 0 0 0.172 0.172
#> 2023-03-29T15:05:36.734 CACHE SET https://team.crunch.io/api/datasets/8e6c08d6a6d4409fb3b13019d72ca258/cube/?QUERY=e6711b4ae7ce0e20ba9cb4c6765eab1e
#>     Count
#> Yes   120
#> No     85
```