### PR TITLE
Fix partial argument match in `getDatasetVariables()`

### DIFF
--- a/R/dataset.R
+++ b/R/dataset.R
@@ -63,7 +63,7 @@ getDatasetVariables <- function(x) {
 
     ## Check cache
     if (useLazyVariableCatalog()) {
-        key <- httpcache::buildCacheKey(varcat_url, query_params, extra = "VariableCatalog")
+        key <- httpcache::buildCacheKey(varcat_url, query_params, extras = "VariableCatalog")
         cache <- httpcache::getCache(key)
         if (!is.null(cache)) {
             return(cache)
@@ -80,7 +80,7 @@ getDatasetVariables <- function(x) {
 getDatasetHiddenVariables <- function(x) {
     varcat_url <- variableCatalogURL(x)
     if (useLazyVariableCatalog()) {
-        key <- httpcache::buildCacheKey(varcat_url, extra = "HiddenVariableCatalog")
+        key <- httpcache::buildCacheKey(varcat_url, extras = "HiddenVariableCatalog")
         cache <- httpcache::getCache(key)
         if (!is.null(cache)) {
             return(cache)
@@ -97,7 +97,7 @@ getDatasetHiddenVariables <- function(x) {
 getDatasetPrivateVariables <- function(x) {
     if (useLazyVariableCatalog()) {
         varcat_url <- variableCatalogURL(x)
-        key <- httpcache::buildCacheKey(varcat_url, extra = "PrivateVariableCatalog")
+        key <- httpcache::buildCacheKey(varcat_url, extras = "PrivateVariableCatalog")
         cache <- httpcache::getCache(key)
         if (!is.null(cache)) {
             return(cache)


### PR DESCRIPTION
Fixes the call to `httpcache::buildCacheKey()` in `getDatasetVariables()`, `getDatasetHiddenVariables()` and `getDatasetPrivateVariables()`. The `extras` argument is now fully spelled out to avoid a partial argument match. With this fix, interactions with a dataset through crunch with the option `warnPartialMatchArgs` set to `TRUE` no longer trigger a warning message.

``` r
options(warnPartialMatchArgs = TRUE)

library(crunch)
set_crunch_opts("crunch.api" = "https://app.crunch.io/api/")
library(httptest)
start_vignette("crunch")
ds <- newDataset(SO_survey, name="Stack Overflow Developer Survey 2017")
dim(ds)
#> [1] 1634   23
```

<sup>Created on 2023-07-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Closes #624.