### PR TITLE
[186417719]: fix path for copying

### DIFF
--- a/docker/jenkins/Dockerfile.rcrunch
+++ b/docker/jenkins/Dockerfile.rcrunch
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install build-essential libtiff5-dev libfribidi-de
 RUN groupadd --gid ${GROUP} jenkins \
     && useradd --uid ${USER} --gid jenkins --shell /bin/bash --create-home -d ${HOMEDIR} jenkins
 # Copy only the minimal amount of the package to install dependencies
-COPY --chown=jenkins:jenkins ./DESCRIPTION ./Makefile ${HOMEDIR}
+COPY --chown=jenkins:jenkins ./DESCRIPTION ./Makefile ${HOMEDIR}/
 WORKDIR ${HOMEDIR}
 RUN echo 'local({\n\
     r <- getOption("repos")\n\


### PR DESCRIPTION
Error is:
```
[2023-11-06T04:34:12.491Z] Step 13/17 : COPY --chown=****:**** ./DESCRIPTION ./Makefile ${HOMEDIR}
[2023-11-06T04:34:12.491Z] When using COPY with more than one source file, the destination must be a directory and end with a /
```

> https://master.ci.crint.net/blue/organizations/jenkins/Build%20Stable%20Images%20for%20our%20k8s%20Backend%20Components/detail/Build%20Stable%20Images%20for%20our%20k8s%20Backend%20Components/9833/pipeline/
