### PR TITLE
[187316637]: increase timeout during testing

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -19,7 +19,7 @@ uncached <- httpcache::uncached
 ## See other options in inst/crunch-test.R
 crunch:::set_crunch_opts(
     crunch.debug = FALSE,
-    crunch.timeout = 20, ## In case an import fails to start, don't wait forever
+    crunch.timeout = 30, ## In case an import fails to start, don't wait forever
     crunch.require.confirmation = TRUE,
     crunch.check.updates = FALSE,
     crunch.namekey.dataset = "alias",


### PR DESCRIPTION
Per slack DMs with @JoshuaFry
> Rcrunch tests on dev are starting to fail often on import-batch . Could you increase the timeout we wait for them to finish? We switched to a new task system and it might take ~5seconds more for the task to get picked out of the task queue group.




