### PR TITLE
[187579809]: fix for unexpected automation error structure

### DIFF
--- a/R/automation.R
+++ b/R/automation.R
@@ -296,9 +296,15 @@ crunchAutomationErrorHandler <- function(response) {
     if (inherits(response, "response")) {
         msg <- http_status(response)$message
         response_content <- content(response)
-    } else {
+    } else if (is.list(response$message)) {
         msg <- response$message$description
         response_content <- response$message
+    } else if (is.character(response$message)) {
+        # Happens when a 500 error occurs during async automation messages
+        halt(response$message)
+    } else {
+        # We're totally confused by the response, but we know there was an error
+        halt("Something went when running the automation script.")
     }
     automation_messages <- try(response_content$resolution, silent = TRUE)
 


### PR DESCRIPTION
A couple of user reports of getting errors like: 
```
  |===================                                                                              |  20%
Something went wrong during `pollProgress()` of url: https://shopperintelligence.crunch.io/api/progress/validate-and-run-script%3Aaa01a1c6907c49b0b63360146221d7f3%24cb296416-a0c3-49f4-bf66-496d2b55ce54/
Result URL: https://shopperintelligence.crunch.io/api/datasets/aa01a1c6907c49b0b63360146221d7f3/scripts/41668c72bd4a441c89443f288b8f2dcb/
Error in response$message$description :
  $ operator is invalid for atomic vectors
```

Using `crGET("https://shopperintelligence.crunch.io/api/progress/validate-and-run-script%3Aaa01a1c6907c49b0b63360146221d7f3%24cb296416-a0c3-49f4-bf66-496d2b55ce54/")` I see that response is not a list as expected for automation because of a 500 error.