### PR TITLE
[ZC-1121]: Handle "var" term in derivations

### DIFF
--- a/R/show.R
+++ b/R/show.R
@@ -282,6 +282,8 @@ formatExpression <- function(expr) {
         }
     } else if ("variable" %in% names(expr)) {
         return(crGET(expr[["variable"]])$body$alias)
+    } else if ("var" %in% names(expr)) {
+        return(expr[["var"]])
     } else if (length(intersect(c("column", "value"), names(expr)))) {
         return(deparseAndFlatten(expressionValue(expr)))
     } else {


### PR DESCRIPTION
Gist: we need this to fix R tests now that we're creating all datasets as alias-based.