### PR TITLE
ZC-4228-Update-Timeout-For-Tests-To-3-Minutes

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -19,7 +19,7 @@ uncached <- httpcache::uncached
 ## See other options in inst/crunch-test.R
 crunch:::set_crunch_opts(
     crunch.debug = FALSE,
-    crunch.timeout = 20, ## In case an import fails to start, don't wait forever
+    crunch.timeout = 180, ## In case an import fails to start, don't wait forever
     crunch.require.confirmation = TRUE,
     crunch.check.updates = FALSE,
     crunch.namekey.dataset = "alias",


### PR DESCRIPTION
Set timeout for tests to 3 minutes to avoid test failures due to tasks running long